### PR TITLE
Refac: Abstracting Board

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,8 @@ PointerBindsToType: false
 AllowShortFunctionsOnASingleLine: false
 BreakBeforeBraces: Attach
 BreakConstructorInitializersBeforeComma: true
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: true
 IndentWidth: 4
 TabWidth: 4
 UseTab: ForIndentation

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,16 @@ test
 *.sdf
 .vs
 imgui.ini
+
+# VS cache files
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+*.tags
+.idea/
+tags

--- a/BRDBoard.cpp
+++ b/BRDBoard.cpp
@@ -1,0 +1,231 @@
+#include "BRDFile.h"
+
+#include "BRDBoard.h"
+#include "platform.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace std::placeholders;
+
+const string BRDBoard::kNetUnconnectedPrefix = "UNCONNECTED";
+const string BRDBoard::kComponentDummyName = "...";
+
+BRDBoard::BRDBoard(const BRDFile *const boardFile)
+    : m_file(boardFile) {
+	// TODO: strip / trim all strings, especially those used as keys
+	// TODO: just loop through original arrays?
+	vector<BRDPart> m_parts(m_file->num_parts);
+	vector<BRDPin> m_pins(m_file->num_pins);
+	vector<BRDNail> m_nails(m_file->num_nails);
+	vector<BRDPoint> m_points(m_file->num_format);
+
+	m_parts.assign(m_file->parts, m_file->parts + m_file->num_parts);
+	m_pins.assign(m_file->pins, m_file->pins + m_file->num_pins);
+	m_nails.assign(m_file->nails, m_file->nails + m_file->num_nails);
+	m_points.assign(m_file->format, m_file->format + m_file->num_format);
+
+	// Set outline
+	{
+		for (auto &brdPoint : m_points) {
+			auto point = make_shared<Point>(brdPoint.x, brdPoint.y);
+			outline_.push_back(point);
+		}
+	}
+
+	// Populate map of unique nets
+	SharedStringMap<Net> net_map;
+	{
+		// adding special net 'UNCONNECTED'
+		auto net_nc = make_shared<Net>();
+		net_nc->name = kNetUnconnectedPrefix;
+		net_nc->is_ground = false;
+		net_map[net_nc->name] = net_nc;
+
+		// handle all the others
+		for (auto &brd_nail : m_nails) {
+			auto net = make_shared<Net>();
+
+			// copy NET name and number (probe)
+			net->name = string(brd_nail.net);
+
+			// avoid having multiple UNCONNECTED<XXX> references
+			if (is_prefix(kNetUnconnectedPrefix, net->name))
+				continue;
+
+			// check whether the pin represents ground
+			net->is_ground = (net->name == "GND");
+			net->number = brd_nail.probe;
+
+			if (brd_nail.side == 1) {
+				net->board_side = kBoardSideTop;
+			} else {
+				net->board_side = kBoardSideBottom;
+			}
+
+			// so we can find nets later by name (making unique by name)
+			net_map[net->name] = net;
+		}
+	}
+
+	// Populate parts
+	{
+		for (auto &brd_part : m_parts) {
+			auto comp = make_shared<Component>();
+
+			comp->name = string(brd_part.name);
+
+			// is it some dummy component to indicate test pads?
+			if (is_prefix(kComponentDummyName, comp->name))
+				comp->component_type = Component::kComponentTypeDummy;
+
+			// check what side the board is on (sorcery?)
+			if (brd_part.type < 8 && brd_part.type >= 4) {
+				comp->board_side = kBoardSideTop;
+			} else if (brd_part.type >= 8) {
+				comp->board_side = kBoardSideBottom;
+			} else {
+				comp->board_side = kBoardSideBoth; // ???
+			}
+
+			comp->mount_type =
+			    (brd_part.type & 0xc) ? Component::kMountTypeSMD : Component::kMountTypeDIP;
+
+			components_.push_back(comp);
+		}
+	}
+
+	// Populate pins
+	{
+		// generate dummy component as reference
+		auto comp_dummy = make_shared<Component>();
+		comp_dummy->name = kComponentDummyName;
+		comp_dummy->component_type = Component::kComponentTypeDummy;
+
+		// NOTE: originally the pin diameter depended on part.name[0] == 'U' ?
+		int pin_idx = 0;
+		int part_idx = 1;
+		auto pins = m_pins;
+		auto parts = m_parts;
+
+		for (int i = 0; i < pins.size(); i++) {
+			// (originally from BoardView::DrawPins)
+			const BRDPin &brd_pin = pins[i];
+			const BRDPart &brd_part = parts[brd_pin.part - 1];
+			Component *comp = components_[brd_pin.part - 1].get();
+
+			auto pin = make_shared<Pin>();
+
+			if (comp->is_dummy()) {
+				// component is virtual, i.e. "...", pin is test pad
+				pin->type = Pin::kPinTypeTestPad;
+				pin->component = comp_dummy.get();
+				comp_dummy->pins.push_back(pin.get());
+			} else {
+				// component is regular / not virtual
+				pin->type = Pin::kPinTypeComponent;
+				pin->component = comp;
+				pin->board_side = pin->component->board_side;
+				comp->pins.push_back(pin.get());
+			}
+
+			// determine pin number on part
+			++pin_idx;
+			if (brd_pin.part != part_idx) {
+				part_idx = brd_pin.part;
+				pin_idx = 1;
+			}
+			pin->number = pin_idx;
+
+			// copy position
+			pin->position = Point(brd_pin.pos.x, brd_pin.pos.y);
+
+			// set net reference (here's our NET key string again)
+			string net_name = string(brd_pin.net);
+			if (net_map.count(net_name)) {
+				// there is a net with that name in our map
+				pin->net = net_map[net_name].get();
+
+				if (pin->type == Pin::kPinTypeTestPad) {
+					pin->board_side = pin->net->board_side;
+				}
+			} else {
+				// no net with that name registered, so create one
+				if (!net_name.empty()) {
+					if (is_prefix(kNetUnconnectedPrefix, net_name)) {
+						// pin is unconnected, so reference our special net
+						pin->net = net_map[kNetUnconnectedPrefix].get();
+						pin->type = Pin::kPinTypeNotConnected;
+					} else {
+						// indeed a new net
+						auto net = make_shared<Net>();
+						net->name = net_name;
+						net->board_side = pin->board_side;
+						// NOTE: net->number not set
+						net_map[net_name] = net;
+						pin->net = net.get();
+					}
+				} else {
+					// not sure this can happen -> no info
+					pin->net = nullptr;
+					pin->type = Pin::kPinTypeUnkown;
+				}
+			}
+
+			// TODO: should either depend on file specs or type etc
+			pin->diameter = 0.5f;
+
+			pin->net->pins.push_back(pin.get());
+			pins_.push_back(pin);
+		}
+
+		// remove all dummy components from vector, add our official dummy
+		// TODO: formatting looks a bit off
+		components_.erase(remove_if(begin(components_), end(components_),
+		                            [](shared_ptr<Component> &comp) { return comp->is_dummy(); }),
+		                  end(components_));
+
+		components_.push_back(comp_dummy);
+	}
+
+	// Populate Net vector by using the map. (sorted by keys)
+	for (auto &net : net_map) {
+		nets_.push_back(net.second);
+	}
+
+	// Sort components by name
+	sort(begin(components_), end(components_),
+	     [](shared_ptr<Component> &lhs, shared_ptr<Component> &rhs) {
+		     return lhs->name < rhs->name;
+		 });
+}
+
+BRDBoard::~BRDBoard() {
+}
+
+SharedVector<Component> &BRDBoard::Components() {
+	return components_;
+}
+
+SharedVector<Pin> &BRDBoard::Pins() {
+	return pins_;
+}
+
+SharedVector<Net> &BRDBoard::Nets() {
+	return nets_;
+}
+
+SharedVector<Point> &BRDBoard::OutlinePoints() {
+	return outline_;
+}
+
+Board::EBoardType BRDBoard::BoardType() {
+	return kBoardTypeBRD;
+}

--- a/BRDBoard.h
+++ b/BRDBoard.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Board.h"
+
+#include <memory>
+#include <string.h>
+#include <vector>
+
+using namespace std;
+
+class BRDBoard : public Board {
+  public:
+	BRDBoard(const BRDFile *const boardFile);
+	~BRDBoard();
+
+	const BRDFile *m_file;
+
+	EBoardType BoardType();
+
+	SharedVector<Net> &Nets();
+	SharedVector<Component> &Components();
+	SharedVector<Pin> &Pins();
+	SharedVector<Point> &OutlinePoints();
+
+  private:
+	static const string kNetUnconnectedPrefix;
+	static const string kComponentDummyName;
+
+	SharedVector<Net> nets_;
+	SharedVector<Component> components_;
+	SharedVector<Pin> pins_;
+	SharedVector<Point> outline_;
+};

--- a/BRDFile.h
+++ b/BRDFile.h
@@ -3,28 +3,28 @@
 #include <stdlib.h>
 
 struct BRDPoint {
-	int x;
-	int y;
+    int x;
+    int y;
 };
 
 struct BRDPart {
-	char *name;
-	int type;
-	int end_of_pins;
+    char *name;
+    int type;
+    int end_of_pins;
 };
 
 struct BRDPin {
-	BRDPoint pos;
-	int probe;
-	int part;
-	char *net;
+    BRDPoint pos;
+    int probe;
+    int part;
+    char *net;
 };
 
 struct BRDNail {
-	int probe;
-	BRDPoint pos;
-	int side;
-	char *net;
+    int probe;
+    BRDPoint pos;
+    int side;
+    char *net;
 };
 
 struct BRDFile {

--- a/Board.h
+++ b/Board.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include "BRDFile.h"
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#define EMPTY_STRING ""
+#define kBoardComponentPrefix "c_"
+#define kBoardPinPrefix "p_"
+#define kBoardNetPrefix "n_"
+#define kBoardElementNameLength 127
+
+using namespace std;
+
+struct Point;
+struct BoardElement;
+struct Net;
+struct Pin;
+struct Component;
+
+typedef function<void(const char *)> TcharStringCallback;
+typedef function<void(BoardElement *)> TboardElementCallback;
+
+template <class T>
+using SharedVector = vector<shared_ptr<T>>;
+
+template <class T>
+using SharedStringMap = map<string, shared_ptr<T>>;
+
+enum EBoardSide {
+	kBoardSideTop = 0,
+	kBoardSideBottom = 1,
+	kBoardSideBoth = 2,
+};
+
+// Checking whether str `prefix` is a prefix of str `base`.
+inline static bool is_prefix(string prefix, string base) {
+	if (prefix.size() > base.size())
+		return false;
+
+	auto res = mismatch(prefix.begin(), prefix.end(), base.begin());
+	if (res.first == prefix.end())
+		return true;
+
+	return false;
+}
+
+template <class T>
+inline static bool contains(const T &element, vector<T *> &v) {
+	return find(begin(v), end(v), &element) != end(v);
+}
+
+template <class T>
+inline static bool contains(T &element, vector<T *> &v) {
+	return find(begin(v), end(v), &element) != end(v);
+}
+
+// Any element being on the board.
+struct BoardElement {
+	// Side of the board the element is located. (top, bottom, both?)
+	EBoardSide board_side = kBoardSideBoth;
+
+	// String uniquely identifying this element on the board.
+	virtual string UniqueId() const = 0;
+};
+
+// A point/position on the board relative to top left corner of the board.
+// TODO: not sure how different formats will store this info.
+struct Point {
+	float x, y;
+
+	Point()
+	    : x(0.0f)
+	    , y(0.0f){};
+	Point(float _x, float _y)
+	    : x(_x)
+	    , y(_y){};
+	Point(int _x, int _y)
+	    : x(float(_x))
+	    , y(float(_y)){};
+};
+
+// Shared potential between multiple Pins/Contacts.
+struct Net : BoardElement {
+	int number;
+	string name;
+	bool is_ground;
+
+	vector<Pin *> pins;
+
+	string UniqueId() const {
+		return kBoardNetPrefix + name;
+	}
+};
+
+// Any observeable contact (nails, component pins).
+// Convieniently/Confusingly named Pin not Contact here.
+struct Pin : BoardElement {
+	enum EPinType {
+		kPinTypeUnkown = 0,
+		kPinTypeNotConnected,
+		kPinTypeComponent,
+		kPinTypeVia,
+		kPinTypeTestPad,
+	};
+
+	// Type of Contact, e.g. pin, via, probe/test point.
+	EPinType type;
+
+	// Pin number / Nail count.
+	int number;
+
+	// Position according to board file. (probably in inches)
+	Point position;
+
+	// Contact diameter, e.g. via or pin size. (probably in inches)
+	float diameter;
+
+	// Net this contact is connected to, nulltpr if no info available.
+	Net *net;
+
+	// Contact belonging to this component (pin), nullptr if nail.
+	Component *component;
+
+	string UniqueId() const {
+		return kBoardPinPrefix + std::to_string(number);
+	}
+};
+
+// A component on the board having multiple Pins.
+struct Component : BoardElement {
+	enum EMountType { kMountTypeUnknown = 0, kMountTypeSMD, kMountTypeDIP };
+
+	enum EComponentType {
+		kComponentTypeUnknown = 0,
+		kComponentTypeDummy,
+		kComponentTypeConnector,
+		kComponentTypeIC,
+		kComponentTypeJellyBean
+	};
+
+	// How the part is attached to the board, either SMD, .., through-hole?
+	EMountType mount_type = kMountTypeUnknown;
+
+	// Type of component, eg. resistor, cap, etc.
+	EComponentType component_type = kComponentTypeUnknown;
+
+	// Part name as stored in board file.
+	string name;
+
+	// Pins belonging to this component.
+	vector<Pin *> pins;
+
+	// Mount type as readable string.
+	string mount_type_str() {
+		switch (mount_type) {
+		case Component::kMountTypeSMD:
+			return "SMD";
+		case Component::kMountTypeDIP:
+			return "DIP";
+		default:
+			return "UNKNOWN";
+		}
+	}
+
+	// true if component is not representing a real/physical component.
+	bool is_dummy() {
+		return component_type == kComponentTypeDummy;
+	}
+
+	string UniqueId() const {
+		return kBoardComponentPrefix + name;
+	}
+};
+
+class Board {
+  public:
+	enum EBoardType { kBoardTypeUnknown = 0, kBoardTypeBRD = 0x01, kBoardTypeBDV = 0x02 };
+
+	virtual ~Board() {
+	}
+
+	virtual SharedVector<Net> &Nets() = 0;
+	virtual SharedVector<Component> &Components() = 0;
+	virtual SharedVector<Pin> &Pins() = 0;
+	virtual SharedVector<Point> &OutlinePoints() = 0;
+
+	EBoardType BoardType() {
+		return kBoardTypeUnknown;
+	}
+};

--- a/BoardView.h
+++ b/BoardView.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <stdint.h>
+#include "Board.h"
 #include "imgui/imgui.h"
+#include <stdint.h>
+#include <vector>
 
 struct BRDPart;
 struct BRDFile;
@@ -35,14 +37,43 @@ struct BitVec {
 	}
 };
 
+struct ColorScheme {
+	uint32_t backgroundColor = 0xa0000000;
+	uint32_t partTextColor = 0xff808000;
+	uint32_t boardOutline = 0xff0000ff;
+
+	uint32_t boxColor = 0xffcccccc;
+
+	uint32_t pinDefault = 0xffff0000;
+	uint32_t pinGround = 0xffdd0000;
+	uint32_t pinNotConnected = 0xffdd0000;
+	uint32_t pinTestPad = 0xff888888;
+
+	uint32_t pinSelected = 0xff00ff00;
+	uint32_t pinHighlighted = 0xffffffff;
+	uint32_t pinHighlightSameNet = 0xff99f8ff;
+
+	uint32_t annotationPartAlias = 0xcc00ffff;
+};
+
+enum DrawChannel {
+	kChannelImages = 0,
+	kChannelPolylines = 1,
+	kChannelText = 2,
+	kChannelAnnotations = 3,
+	NUM_DRAW_CHANNELS = 4
+};
+
 struct BoardView {
 	BRDFile *m_file;
-	int m_pinSelected;
-	BitVec m_pinHighlighted;
-	BitVec m_partHighlighted;
+	Board *m_board;
+
+	Pin *m_pinSelected = nullptr;
+	vector<Pin *> m_pinHighlighted;
+	vector<Component *> m_partHighlighted;
 	char m_cachedDrawList[sizeof(ImDrawList)];
 	ImVector<char> m_cachedDrawCommands;
-	ImVector<char *> m_nets;
+	SharedVector<Net> m_nets;
 	char m_search[128];
 	char m_netFilter[128];
 	char *m_lastFileOpenName;
@@ -54,46 +85,64 @@ struct BoardView {
 	float m_lastWidth;
 	float m_lastHeight;
 	int m_rotation;
-	int m_side;
+	int m_current_side;
 	int m_boardWidth;
 	int m_boardHeight;
+
+	ColorScheme m_colors;
 
 	// TODO: save settings to disk
 	// pinDiameter: diameter for all pins.  Unit scale: 1 = 0.025mm
 	int m_pinDiameter = 20;
 	bool m_flipVertically = true;
 
-	// Do a hacky thing (memcpy the window draw list) to save us from rerendering the board
+	// Annotation layer specific
+	bool m_annotationsVisible = true;
+
+	// Do a hacky thing (memcpy the window draw list) to save us from rerendering
+	// the board
 	// The app will crash or break if this flag is not set when it should be.
 	bool m_needsRedraw = true;
 	bool m_draggingLastFrame;
 	bool m_showNetfilterSearch;
 	bool m_showComponentSearch;
+	bool m_showNetList;
+	bool m_showPartList;
 	bool m_firstFrame = true;
 	bool m_lastFileOpenWasInvalid;
 	bool m_wantsQuit;
 
 	~BoardView();
 
+	void ShowNetList(bool *p_open);
+	void ShowPartList(bool *p_open);
+
 	void Update();
 	void HandleInput();
+	void RenderOverlay();
+	void DrawOutline(ImDrawList *draw);
+	void DrawPins(ImDrawList *draw);
+	void DrawParts(ImDrawList *draw);
 	void DrawBoard();
 	void SetFile(BRDFile *file);
 	ImVec2 CoordToScreen(float x, float y, float w = 1.0f);
 	ImVec2 ScreenToCoord(float x, float y, float w = 1.0f);
-	void Move(float x, float y);
+	// void Move(float x, float y);
 	void Rotate(int count);
 
 	// Sets the center of the screen to (x,y) in board space
 	void SetTarget(float x, float y);
 
-	// Returns true if the part is shown on the currently displayed side of the board.
-	bool PartIsVisible(const BRDPart &part);
-	// Returns true if the circle described by screen coordinates x, y, and radius is visible in the
+	// Returns true if the part is shown on the currently displayed side of the
+	// board.
+	bool ElementIsVisible(const BoardElement *part);
+	bool IsVisibleScreen(float x, float y, float radius, const ImGuiIO &io);
+	// Returns true if the circle described by screen coordinates x, y, and radius
+	// is visible in the
 	// ImGuiIO screen rect.
-	bool IsVisibleScreen(float x, float y, float radius = 0.0f);
+	// bool IsVisibleScreen(float x, float y, float radius = 0.0f);
 
-	bool PartIsHighlighted(int part_idx);
+	bool PartIsHighlighted(const Component &component);
 	void SetNetFilter(const char *net);
 	void FindComponent(const char *name);
 	void SetLastFileOpenName(char *name);

--- a/NetList.cpp
+++ b/NetList.cpp
@@ -1,0 +1,51 @@
+#include "NetList.h"
+
+#include "imgui\imgui.h"
+
+NetList::NetList(TcharStringCallback cbNetSelected) {
+	cbNetSelected_ = cbNetSelected;
+}
+
+NetList::~NetList() {
+}
+
+void NetList::Draw(const char *title, bool *p_open, Board *board) {
+	// TODO: export / fix dimensions & behaviour
+	int width = 400;
+	int height = 640;
+
+	ImGui::SetNextWindowSize(ImVec2(width, height));
+	ImGui::Begin("Net List");
+
+	ImGui::Columns(1, "part_infos");
+	ImGui::Separator();
+
+	ImGui::Text("Name");
+	ImGui::NextColumn();
+	ImGui::Separator();
+
+	if (board) {
+		auto nets = board->Nets();
+
+		ImGuiListClipper clipper(nets.size(), ImGui::GetTextLineHeight());
+		static int selected = -1;
+		string net_name = "";
+		for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++) {
+			net_name = nets[i]->name;
+			if (ImGui::Selectable(net_name.c_str(), selected == i,
+			                      ImGuiSelectableFlags_SpanAllColumns |
+			                          ImGuiSelectableFlags_AllowDoubleClick)) {
+				selected = i;
+				if (ImGui::IsMouseDoubleClicked(0)) {
+					cbNetSelected_(net_name.c_str());
+				}
+			}
+			ImGui::NextColumn();
+		}
+		clipper.End();
+	}
+	ImGui::Columns(1);
+	ImGui::Separator();
+
+	ImGui::End();
+}

--- a/NetList.h
+++ b/NetList.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Board.h"
+
+#include <vector>
+
+class NetList {
+
+  public:
+	NetList(TcharStringCallback cbNetSelected);
+	~NetList();
+
+	void Draw(const char *title, bool *p_open, Board *board);
+
+  private:
+	TcharStringCallback cbNetSelected_;
+};

--- a/OpenBoardView.vcxproj
+++ b/OpenBoardView.vcxproj
@@ -127,7 +127,9 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Board.h" />
     <ClInclude Include="BoardView.h" />
+    <ClInclude Include="BRDBoard.h" />
     <ClInclude Include="BRDFile.h" />
     <ClInclude Include="imgui\imconfig.h" />
     <ClInclude Include="imgui\imgui.h" />
@@ -136,17 +138,22 @@
     <ClInclude Include="imgui\stb_textedit.h" />
     <ClInclude Include="imgui\stb_truetype.h" />
     <ClInclude Include="imgui_impl_dx9.h" />
+    <ClInclude Include="NetList.h" />
+    <ClInclude Include="PartList.h" />
     <ClInclude Include="platform.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BoardView.cpp" />
+    <ClCompile Include="BRDBoard.cpp" />
     <ClCompile Include="BRDFile.cpp" />
     <ClCompile Include="imgui\imgui.cpp" />
     <ClCompile Include="imgui\imgui_demo.cpp" />
     <ClCompile Include="imgui\imgui_draw.cpp" />
     <ClCompile Include="imgui_impl_dx9.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="NetList.cpp" />
+    <ClCompile Include="PartList.cpp" />
     <ClCompile Include="platform.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/OpenBoardView.vcxproj.filters
+++ b/OpenBoardView.vcxproj.filters
@@ -26,6 +26,10 @@
     <ClInclude Include="BRDFile.h" />
     <ClInclude Include="platform.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="NetList.h" />
+    <ClInclude Include="Board.h" />
+    <ClInclude Include="BRDBoard.h" />
+    <ClInclude Include="PartList.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="imgui\imgui.cpp">
@@ -48,6 +52,9 @@
     </ClCompile>
     <ClCompile Include="BRDFile.cpp" />
     <ClCompile Include="BoardView.cpp" />
+    <ClCompile Include="NetList.cpp" />
+    <ClCompile Include="BRDBoard.cpp" />
+    <ClCompile Include="PartList.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="imgui">

--- a/PartList.cpp
+++ b/PartList.cpp
@@ -1,0 +1,51 @@
+#include "PartList.h"
+
+#include "imgui\imgui.h"
+
+PartList::PartList(TcharStringCallback cbNetSelected) {
+	cbNetSelected_ = cbNetSelected;
+}
+
+PartList::~PartList() {
+}
+
+void PartList::Draw(const char *title, bool *p_open, Board *board) {
+	// TODO: export / fix dimensions & behaviour
+	int width = 400;
+	int height = 640;
+
+	ImGui::SetNextWindowSize(ImVec2(width, height));
+	ImGui::Begin("Part List");
+
+	ImGui::Columns(1, "part_infos");
+	ImGui::Separator();
+
+	ImGui::Text("Name");
+	ImGui::NextColumn();
+	ImGui::Separator();
+
+	if (board) {
+		auto parts = board->Components();
+
+		ImGuiListClipper clipper(parts.size(), ImGui::GetTextLineHeight());
+		static int selected = -1;
+		string part_name = "";
+		for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++) {
+			part_name = parts[i]->name;
+
+			if (ImGui::Selectable(part_name.c_str(), selected == i,
+			                      ImGuiSelectableFlags_AllowDoubleClick)) {
+				selected = i;
+				if (ImGui::IsMouseDoubleClicked(0)) {
+					cbNetSelected_(part_name.c_str());
+				}
+			}
+			ImGui::NextColumn();
+		}
+		clipper.End();
+	}
+	ImGui::Columns(1);
+	ImGui::Separator();
+
+	ImGui::End();
+}

--- a/PartList.h
+++ b/PartList.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "BRDFile.h"
+#include "Board.h"
+
+class PartList {
+  public:
+	PartList(TcharStringCallback cbNetSelected);
+	~PartList();
+
+	void Draw(const char *title, bool *p_open, Board *board);
+
+  private:
+	TcharStringCallback cbNetSelected_;
+};


### PR DESCRIPTION
This is an attempt to abstact away `BRDFile`. `BoardView` then uses it in a 
more object-oriented way. This comes with some downsides, especially 
considering performance (at least as it is now).

Apart from that most things work as before.

 * Abstract `Board` class to encapsulate/abstract
   - derived `BRDBoard` holds a `BRDFile` instance
   - provides Nets, Parts and Pins in vectors

 * Exported most colors to struct

 * Separated draw procedures for different elements
 
 * Added Net list and Component list
   - double click to select

 * Added annotations layer for possible custom content

WIP:

 * Only using `Board` objects in `BoardView`

----------------------
I tested most of this on MacOS and MinGW by merging piernov's branch.

`Board` is an abstract class where `BRDBoard`, holding a `BRDFile` instance, is an imlementation for BRD files. Other formats should be fairly easy to integrate now.

* *Pin* - any contact on the board (test pads, probably vias, chip pins)
  - a Pin may connect to one Net and belong to one Component
* *Net* - a 'potential' that multiple Pins are connected to (e.g. our friend `pp3v3` or `GND`)
  - holds references to all pins connected to it
* *Component* - any component on the board (connectors, resistors, ICs, etc.)
  - holds references to all pins associated with it

The original implementation is very efficient, since it looped over arrays of structs (directly derived from the source file). But different files have different structures so drawing and _extending those structures, e.g. by annotations_ imo is harder not going full OOP and I hope this implementation using the right data structures can keep up with the original one in near future. It's still quite ok on my machine.

Net list and Component list and other parts probably need some more work.