### PR TITLE
Default to .brd filetype filter

### DIFF
--- a/platform.cpp
+++ b/platform.cpp
@@ -69,7 +69,7 @@ char *show_file_picker() {
 	memset(&ofn, 0, sizeof(ofn));
 	ofn.lStructSize = sizeof(ofn);
 	ofn.hwndOwner = (HWND)ImGui::GetIO().ImeWindowHandle;
-	ofn.lpstrFilter = L"All Files\0*.*\0\0";
+	ofn.lpstrFilter = L"BRD Files\0*.brd\0All Files\0*.*\0\0";
 	ofn.lpstrFile = filename;
 	ofn.nMaxFile = 1024;
 	if (GetOpenFileName(&ofn)) {


### PR DESCRIPTION
Quick usability fix - default to showing only "*.brd" files, with the option to select "All Files" if your board file has a non-standard extension. 