### PR TITLE
Usability improvements

### DIFF
--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -334,6 +334,39 @@ void BoardView::HandleInput() {
 			target.y *= 0.5f;
 			ChangeZoom(target, 0.5f);
 		}
+
+		//Arrow keys or WASD to move viewport by a percentage of the screen width/height
+		{
+			ImVec2 delta(0.0f, 0.0f);
+			
+			float dist = 0.25f;
+
+			// Ctrl slows down the movement speed
+			if (ImGui::IsKeyDown(17)) {
+				dist *= 0.1f;
+			}
+
+			if (ImGui::IsKeyPressed('W') || ImGui::IsKeyPressed(38))
+				delta.y = dist;
+			if (ImGui::IsKeyPressed('S') || ImGui::IsKeyPressed(40))
+				delta.y = -dist;
+			if (ImGui::IsKeyPressed('A') || ImGui::IsKeyPressed(37))
+				delta.x = dist;
+			if (ImGui::IsKeyPressed('D') || ImGui::IsKeyPressed(39))
+				delta.x = -dist;
+
+			if (delta.x != 0.0f || delta.y != 0.0f) {
+
+				//Account for zoom level by using screen coordinates (TODO easier using m_scale?)
+				ImVec2 dims = ImGui::GetWindowSize();
+				ImVec2 dimc = ScreenToCoord(dims.x, dims.y, 0);
+				ImVec2 c = ScreenToCoord(0.0f, 0.0f, 0);
+				ImVec2 motion((dimc.x-c.x)*delta.x, (dimc.y-c.y)*delta.y);
+				m_dx += motion.x;
+				m_dy += motion.y;
+				m_needsRedraw = true;
+			}
+		}
 		
 		// Flip board:
 		if (ImGui::IsKeyPressed(' ')) {

--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -28,6 +28,11 @@ BoardView::~BoardView() {
 	free(m_lastFileOpenName);
 }
 
+void BoardView::ShowError(char* msg) {
+	m_lastErrorMsg = msg;
+	m_showError = true;
+}
+
 #pragma region Update Logic
 void BoardView::Update() {
 	bool open_file = false;
@@ -43,7 +48,7 @@ void BoardView::Update() {
 			if (ImGui::MenuItem("Open", "Ctrl+O")) {
 				open_file = true;
 			}
-			if (ImGui::MenuItem("Quit")) {
+			if (ImGui::MenuItem("Quit", "Ctrl+Q")) {
 				m_wantsQuit = true;
 			}
 			ImGui::EndMenu();
@@ -86,9 +91,9 @@ void BoardView::Update() {
 		if (m_showComponentSearch && m_file) {
 			ImGui::OpenPopup("Search for Component");
 		}
-		if (m_lastFileOpenWasInvalid) {
-			ImGui::OpenPopup("Error opening file");
-			m_lastFileOpenWasInvalid = false;
+		if (m_showError) {
+			ImGui::OpenPopup("Error");
+			m_showError = false;
 		}
 		if (ImGui::BeginPopupModal("Search for Net", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
 			if (m_showNetfilterSearch) {
@@ -203,9 +208,8 @@ void BoardView::Update() {
 			    "SOFTWARE.");
 			ImGui::EndPopup();
 		}
-		if (ImGui::BeginPopupModal("Error opening file")) {
-			ImGui::Text("There was an error opening the file: %s", m_lastFileOpenName);
-			// TODO: error details? -- would need the loader to say what's wrong.
+		if (ImGui::BeginPopupModal("Error")) {
+			ImGui::Text("There was an error: %s", m_lastErrorMsg);
 			if (ImGui::Button("OK")) {
 				ImGui::CloseCurrentPopup();
 			}
@@ -937,7 +941,7 @@ void BoardView::OpenFile(char * filename)
 			m_wantsTitleChange = true;
 		}
 		else {
-			m_lastFileOpenWasInvalid = true;
+			ShowError("Cannot parse the file.");
 			delete file;
 		}
 		free(buffer);

--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -334,38 +334,58 @@ void BoardView::HandleInput() {
 	}
 	if (!io.WantCaptureKeyboard) {
 
-		// (I/+) and (O/-) keys as alternate zoom. Will zoom on the centre of the viewport, not on the mouse.
-		if (ImGui::IsKeyPressed('I') || ImGui::IsKeyPressed(187)) {
-			ImVec2 target = ImGui::GetWindowSize();
-			target.x *= 0.5f;
-			target.y *= 0.5f;
-			ChangeZoom(target, 2.0f);
+		//Ctrl-Q as alternative quit shortcut (Alt-F4 is already handled by Windows)
+		if (ImGui::IsKeyPressed('Q') && ImGui::IsKeyDown(17)) {
+			m_wantsQuit = true;
 		}
-		if (ImGui::IsKeyPressed('O') || ImGui::IsKeyPressed(189)) {
+
+		// (I/+/PgUp) and (O/-/PgDn) keys as alternate zoom. Will zoom on the centre of the viewport, not on the mouse.
+		
+		//TODO numpad +/- scancodes
+		if ( ImGui::IsKeyPressed('I')
+			|| ImGui::IsKeyPressed(187)
+			|| ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_PageUp))
+			)
+		{
 			ImVec2 target = ImGui::GetWindowSize();
 			target.x *= 0.5f;
 			target.y *= 0.5f;
-			ChangeZoom(target, 0.5f);
+
+			float zoom = 2.0f;
+			ChangeZoom(target, zoom);
+		}
+
+		if ( ImGui::IsKeyPressed('O') 
+			|| ImGui::IsKeyPressed(189)
+			|| ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_PageDown))
+			)
+		{
+			ImVec2 target = ImGui::GetWindowSize();
+			target.x *= 0.5f;
+			target.y *= 0.5f;
+			
+			float zoom = 0.5f;
+			ChangeZoom(target, zoom);
 		}
 
 		//Arrow keys or WASD to move viewport by a percentage of the screen width/height
 		{
 			ImVec2 delta(0.0f, 0.0f);
 			
-			float dist = 0.25f;
+			float dist = 0.125f;
 
 			// Ctrl slows down the movement speed
 			if (ImGui::IsKeyDown(17)) {
 				dist *= 0.1f;
 			}
 
-			if (ImGui::IsKeyPressed('W') || ImGui::IsKeyPressed(38))
+			if (ImGui::IsKeyPressed('W') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_UpArrow)))
 				delta.y = dist;
-			if (ImGui::IsKeyPressed('S') || ImGui::IsKeyPressed(40))
+			if (ImGui::IsKeyPressed('S') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_DownArrow)))
 				delta.y = -dist;
-			if (ImGui::IsKeyPressed('A') || ImGui::IsKeyPressed(37))
+			if (ImGui::IsKeyPressed('A') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_LeftArrow)))
 				delta.x = dist;
-			if (ImGui::IsKeyPressed('D') || ImGui::IsKeyPressed(39))
+			if (ImGui::IsKeyPressed('D') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_RightArrow)))
 				delta.x = -dist;
 
 			if (delta.x != 0.0f || delta.y != 0.0f) {

--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -11,8 +11,7 @@
 #endif
 
 BoardView::~BoardView() {
-	if (m_file)
-		delete m_file;
+	delete m_file;
 	free(m_lastFileOpenName);
 }
 
@@ -525,8 +524,7 @@ int qsort_netstrings(const void *a, const void *b) {
 }
 
 void BoardView::SetFile(BRDFile *file) {
-	if (m_file)
-		delete m_file;
+	delete m_file;
 	m_file = file;
 
 	// Generate sorted, uniqued list of nets:

--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -348,7 +348,8 @@ void BoardView::HandleInput() {
 		//TODO numpad +/- scancodes
 		if ( ImGui::IsKeyPressed('I')
 			|| ImGui::IsKeyPressed(187)
-			|| ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_PageUp))
+			|| ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_PageUp)
+			|| ImGui::IsKeyPressed(0x6B) )
 			)
 		{
 			ImVec2 target = ImGui::GetWindowSize();
@@ -361,7 +362,8 @@ void BoardView::HandleInput() {
 
 		if ( ImGui::IsKeyPressed('O') 
 			|| ImGui::IsKeyPressed(189)
-			|| ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_PageDown))
+			|| ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_PageDown)
+			|| ImGui::IsKeyPressed(0x6D) )
 			)
 		{
 			ImVec2 target = ImGui::GetWindowSize();
@@ -383,13 +385,13 @@ void BoardView::HandleInput() {
 				dist *= 0.1f;
 			}
 
-			if (ImGui::IsKeyPressed('W') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_UpArrow)))
+			if (ImGui::IsKeyPressed('W') || ImGui::IsKeyPressed(0x68) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_UpArrow)))
 				delta.y = dist;
-			if (ImGui::IsKeyPressed('S') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_DownArrow)))
+			if (ImGui::IsKeyPressed('S') || ImGui::IsKeyPressed(0x62) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_DownArrow)))
 				delta.y = -dist;
-			if (ImGui::IsKeyPressed('A') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_LeftArrow)))
+			if (ImGui::IsKeyPressed('A') || ImGui::IsKeyPressed(0x64) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_LeftArrow)))
 				delta.x = dist;
-			if (ImGui::IsKeyPressed('D') || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_RightArrow)))
+			if (ImGui::IsKeyPressed('D') || ImGui::IsKeyPressed(0x66) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_RightArrow)))
 				delta.x = -dist;
 
 			if (delta.x != 0.0f || delta.y != 0.0f) {

--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -30,6 +30,21 @@ void BoardView::Update() {
 			if (ImGui::MenuItem("Open", "Ctrl+O")) {
 				open_file = true;
 			}
+			if (ImGui::MenuItem("Quit")) {
+				m_wantsQuit = true;
+			}
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("View")) {
+			if (ImGui::MenuItem("Flip board", "<Space>")) {
+				FlipBoard();
+			}
+			if (ImGui::MenuItem("Rotate CW", ".")) {
+				Rotate(1);
+			}
+			if (ImGui::MenuItem("Rotate CCW", ",")) {
+				Rotate(-1);
+			}
 			ImGui::EndMenu();
 		}
 		if (ImGui::Button("Net")) {
@@ -305,11 +320,9 @@ void BoardView::HandleInput() {
 		// Rotate board: R and period rotate clockwise; comma rotates counter-clockwise
 		if (ImGui::IsKeyPressed('R') || ImGui::IsKeyPressed(190)) {
 			Rotate(1);
-			m_needsRedraw = true;
 		}
 		if (ImGui::IsKeyPressed(188)) {
 			Rotate(-1);
-			m_needsRedraw = true;
 		}
 
 		// Search for net
@@ -622,6 +635,7 @@ void BoardView::Rotate(int count) {
 			m_dy = -dx;
 		}
 		--count;
+		m_needsRedraw = true;
 	}
 	while (count < 0) {
 		m_rotation = (m_rotation - 1) & 3;
@@ -635,6 +649,7 @@ void BoardView::Rotate(int count) {
 			m_dy = -dx;
 		}
 		++count;
+		m_needsRedraw = true;
 	}
 }
 

--- a/BoardView.cpp
+++ b/BoardView.cpp
@@ -470,8 +470,8 @@ void BoardView::DrawBoard() {
 			color = 0xff333333;
 			is_test_pad = true;
 		}
-		ImVec2 min = CoordToScreen(min_x, min_y);
-		ImVec2 max = CoordToScreen(max_x, max_y);
+		ImVec2 min = CoordToScreen((float)min_x, (float)min_y);
+		ImVec2 max = CoordToScreen((float)max_x, (float)max_y);
 		min.x -= 0.5f;
 		max.x += 0.5f;
 		draw->AddRect(min, max, color);

--- a/BoardView.h
+++ b/BoardView.h
@@ -71,6 +71,7 @@ struct BoardView {
 	bool m_showComponentSearch;
 	bool m_firstFrame = true;
 	bool m_lastFileOpenWasInvalid;
+	bool m_wantsQuit;
 
 	~BoardView();
 

--- a/BoardView.h
+++ b/BoardView.h
@@ -76,6 +76,7 @@ struct BoardView {
 	~BoardView();
 
 	void Update();
+	void ChangeZoom(ImVec2 coord, float scale);
 	void HandleInput();
 	void DrawBoard();
 	void SetFile(BRDFile *file);

--- a/BoardView.h
+++ b/BoardView.h
@@ -77,6 +77,7 @@ struct BoardView {
 	char m_search[128];
 	char m_netFilter[128];
 	char *m_lastFileOpenName;
+	char *m_lastErrorMsg;
 	float m_dx;
 	float m_dy;
 	float m_mx;
@@ -109,11 +110,13 @@ struct BoardView {
 	bool m_showNetList;
 	bool m_showPartList;
 	bool m_firstFrame = true;
-	bool m_lastFileOpenWasInvalid;
+	bool m_showError;
 	bool m_wantsQuit;
 	bool m_wantsTitleChange;
 
 	~BoardView();
+
+	void ShowError(char * msg);
 
 	void ShowNetList(bool *p_open);
 	void ShowPartList(bool *p_open);

--- a/OpenBoardView.vcxproj
+++ b/OpenBoardView.vcxproj
@@ -157,9 +157,7 @@
     <ResourceCompile Include="OpenBoardView.rc" />
   </ItemGroup>
   <ItemGroup>
-    <Font Include="asset\FiraMono-Regular.ttf" />
     <Font Include="asset\FiraSans-Medium.ttf" />
-    <Font Include="asset\OpenSans-Regular.ttf" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/OpenBoardView.vcxproj.filters
+++ b/OpenBoardView.vcxproj.filters
@@ -67,15 +67,13 @@
     <Image Include="asset\brd.ico" />
   </ItemGroup>
   <ItemGroup>
-    <Font Include="asset\FiraMono-Regular.ttf">
-      <Filter>assets</Filter>
-    </Font>
-    <Font Include="asset\OpenSans-Regular.ttf" />
-    <Font Include="asset\FiraSans-Medium.ttf" />
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="OpenBoardView.rc">
       <Filter>assets</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Font Include="asset\FiraSans-Medium.ttf">
+      <Filter>assets</Filter>
+    </Font>
   </ItemGroup>
 </Project>

--- a/main.cpp
+++ b/main.cpp
@@ -77,6 +77,7 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	LPDIRECT3D9 pD3D;
 	if ((pD3D = Direct3DCreate9(D3D_SDK_VERSION)) == NULL) {
 		UnregisterClass(class_name, wc.hInstance);
+		MessageBox(hwnd, L"Failed to initialise Direct3D", NULL, 0);
 		return 0;
 	}
 	ZeroMemory(&g_d3dpp, sizeof(g_d3dpp));
@@ -92,6 +93,7 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	                       D3DCREATE_HARDWARE_VERTEXPROCESSING, &g_d3dpp, &g_pd3dDevice) < 0) {
 		pD3D->Release();
 		UnregisterClass(class_name, wc.hInstance);
+		MessageBox(hwnd, L"Failed to create Direct3D device", NULL, 0);
 		return 0;
 	}
 

--- a/main.cpp
+++ b/main.cpp
@@ -173,6 +173,9 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 		}
 #endif
 		app.Update();
+		if (app.m_wantsQuit) {
+			PostMessage(hwnd, WM_QUIT, 0, 0);
+		}
 
 		// Rendering
 		g_pd3dDevice->SetRenderState(D3DRS_ZENABLE, false);

--- a/main.cpp
+++ b/main.cpp
@@ -154,7 +154,7 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			uFile = DragQueryFile(hDrop, 0xFFFFFFFF, NULL, NULL);
 
 			if (uFile > 1) {
-				MessageBox(hwnd, _T("Dropping multiple files is not supported."), NULL, MB_ICONERROR);
+				app.ShowError("Multiple files not supported");
 			}
 			else {
 				lpszFile[0] = '\0';

--- a/platform.h
+++ b/platform.h
@@ -8,6 +8,8 @@ char *file_as_buffer(size_t *buffer_size, const char *utf8_filename);
 
 // Shows a file dialog (should hang the current thread) and returns the utf8 filename picked by the
 // user or nullptr.  If non-null is returned, it must be later freed by the caller.
+// File type filtering must be implemented separately in each and every one of these functions (this could be
+// done in a more elegant way in the future, if the scope of the project expands to include lots of formats)
 char *show_file_picker();
 
 // these mirror the Windows .rc definitions:

--- a/platform_osx.mm
+++ b/platform_osx.mm
@@ -7,6 +7,10 @@ char *show_file_picker() {
 	std::string filename;
 	NSOpenPanel *op = [NSOpenPanel openPanel];
 
+	// Filter file types
+	[op setCanChooseFiles:YES];
+	[op setAllowedFileTypes:@[@"brd"]];
+
 	if ([op runModal] == NSModalResponseOK) {
 		NSURL *nsurl = [[op URLs] objectAtIndex:0];
 		filename = std::string([[nsurl path] UTF8String]);

--- a/platform_unix.cpp
+++ b/platform_unix.cpp
@@ -51,6 +51,11 @@ char *show_file_picker() {
 					"_Open", GTK_RESPONSE_ACCEPT,
 					NULL );
 
+	// Filter file types
+	GtkFileFilter *filter = gtk_file_filter_new();
+	gtk_file_filter_add_pattern(filter, "*.brd");
+	gtk_file_chooser_add_filter(dialog, filter);
+
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 		char *filename = nullptr;
 


### PR DESCRIPTION
Add a bunch of minor usability tweaks:

* Defaults to .brd file type on Linux, OS X and Windows, with an option for "All Files" if your board file has an odd extension (untested on anything except Windows)
* Shows error messages if DirectX fails to initialise
* Adds keyboard controls to move the viewport around (caveat: behaves oddly when rotated at 90 and 270 degrees - will refactor/fix this soon)
* Drag and drop to open file on Windows
* Window title shows filename on Windows