### PR TITLE
cmake: Add uninstall target

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,6 @@ trim_trailing_whitespace = true
 
 
 # Code files
-[{*.{h,c,cc,cpp,mm},CMakeLists.txt}]
+[{*.{h,c,cc,cpp,mm,.cmake},CMake*}]
 indent_style = tab
 indent_size = 4

--- a/CMake/cmake_uninstall.cmake.in
+++ b/CMake/cmake_uninstall.cmake.in
@@ -1,0 +1,33 @@
+## CMakeUninstall
+#
+# By default, CMake does not provide the "make uninstall" target. This is
+# intended to prevent "make uninstall" from removing useful files from the
+# system.
+#
+# This file provides the basis for a "uninstall" build target. It is used to
+# delete the files listed in install_manifest.txt.
+#
+# This file is taken from https://cmake.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F
+#
+
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+	message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+	message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+	if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+		exec_program(
+			"@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+			OUTPUT_VARIABLE rm_out
+			RETURN_VALUE rm_retval
+			)
+		if(NOT "${rm_retval}" STREQUAL 0)
+			message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+		endif(NOT "${rm_retval}" STREQUAL 0)
+	else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+		message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+	endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,17 @@ set_property(
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
 
+# uninstall target
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/CMake/cmake_uninstall.cmake.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/CMake/cmake_uninstall.cmake"
+	IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+set_target_properties(uninstall PROPERTIES FOLDER "Meta Targets")
+
+
 
 # Enable packaging installers
 include(CPack)


### PR DESCRIPTION
Add a target that removes all files listed in `install_manifest.txt` (i.e. all files installed by the `install` target).

This is useful if you want to build the `install` target instead of using a package or running the binary from the build directory.

This is more intended for the unix stuff, where people are more likely to be silly and use `make install`