### PR TITLE
Adjust clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,35 @@
+# .clang-format (YAML)
+
 BasedOnStyle: LLVM
-PointerBindsToType: false
-AllowShortFunctionsOnASingleLine: false
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+
+# Used for line wrapping and defining a "short" statement
+ColumnLimit: 100
+
+# Allow short statements on one line
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+
+# Sensible alignments
+AlignConsecutiveAssignments: false
+AlignOperands: true
+AlignEscapedNewlinesLeft: true
+AlignAfterOpenBracket: Align
+BinPackArguments:  false # Break after each arg if they won't fit on one line
+BinPackParameters: false
+
+# Line breaks
 BreakBeforeBraces: Attach
 BreakConstructorInitializersBeforeComma: true
 AlwaysBreakTemplateDeclarations: true
 AlwaysBreakBeforeMultilineStrings: true
-IndentWidth: 4
-TabWidth: 4
-UseTab: ForIndentation
-ColumnLimit: 100
+
+# Misc
+PointerBindsToType: false
+IndentCaseLabels: true

--- a/src/BRDBoard.cpp
+++ b/src/BRDBoard.cpp
@@ -57,8 +57,7 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 			net->name = string(brd_nail.net);
 
 			// avoid having multiple UNCONNECTED<XXX> references
-			if (is_prefix(kNetUnconnectedPrefix, net->name))
-				continue;
+			if (is_prefix(kNetUnconnectedPrefix, net->name)) continue;
 
 			// check whether the pin represents ground
 			net->is_ground = (net->name == "GND");
@@ -188,7 +187,8 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 
 		// remove all dummy components from vector, add our official dummy
 		// TODO: formatting looks a bit off
-		components_.erase(remove_if(begin(components_), end(components_),
+		components_.erase(remove_if(begin(components_),
+		                            end(components_),
 		                            [](shared_ptr<Component> &comp) { return comp->is_dummy(); }),
 		                  end(components_));
 
@@ -201,14 +201,14 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 	}
 
 	// Sort components by name
-	sort(begin(components_), end(components_),
+	sort(begin(components_),
+	     end(components_),
 	     [](shared_ptr<Component> &lhs, shared_ptr<Component> &rhs) {
 		     return lhs->name < rhs->name;
 		 });
 }
 
-BRDBoard::~BRDBoard() {
-}
+BRDBoard::~BRDBoard() {}
 
 SharedVector<Component> &BRDBoard::Components() {
 	return components_;

--- a/src/BRDFile.h
+++ b/src/BRDFile.h
@@ -3,28 +3,28 @@
 #include <stdlib.h>
 
 struct BRDPoint {
-    int x;
-    int y;
+	int x;
+	int y;
 };
 
 struct BRDPart {
-    char *name;
-    int type;
-    int end_of_pins;
+	char *name;
+	int type;
+	int end_of_pins;
 };
 
 struct BRDPin {
-    BRDPoint pos;
-    int probe;
-    int part;
-    char *net;
+	BRDPoint pos;
+	int probe;
+	int part;
+	char *net;
 };
 
 struct BRDNail {
-    int probe;
-    BRDPoint pos;
-    int side;
-    char *net;
+	int probe;
+	BRDPoint pos;
+	int side;
+	char *net;
 };
 
 struct BRDFile {

--- a/src/Board.h
+++ b/src/Board.h
@@ -40,12 +40,10 @@ enum EBoardSide {
 
 // Checking whether str `prefix` is a prefix of str `base`.
 inline static bool is_prefix(string prefix, string base) {
-	if (prefix.size() > base.size())
-		return false;
+	if (prefix.size() > base.size()) return false;
 
 	auto res = mismatch(prefix.begin(), prefix.end(), base.begin());
-	if (res.first == prefix.end())
-		return true;
+	if (res.first == prefix.end()) return true;
 
 	return false;
 }
@@ -159,12 +157,9 @@ struct Component : BoardElement {
 	// Mount type as readable string.
 	string mount_type_str() {
 		switch (mount_type) {
-		case Component::kMountTypeSMD:
-			return "SMD";
-		case Component::kMountTypeDIP:
-			return "DIP";
-		default:
-			return "UNKNOWN";
+			case Component::kMountTypeSMD: return "SMD";
+			case Component::kMountTypeDIP: return "DIP";
+			default: return "UNKNOWN";
 		}
 	}
 
@@ -182,8 +177,7 @@ class Board {
   public:
 	enum EBoardType { kBoardTypeUnknown = 0, kBoardTypeBRD = 0x01, kBoardTypeBDV = 0x02 };
 
-	virtual ~Board() {
-	}
+	virtual ~Board() {}
 
 	virtual SharedVector<Net> &Nets() = 0;
 	virtual SharedVector<Component> &Components() = 0;

--- a/src/BoardView.cpp
+++ b/src/BoardView.cpp
@@ -130,8 +130,8 @@ void BoardView::Update() {
 			}
 			ImGui::EndPopup();
 		}
-		if (ImGui::BeginPopupModal("Search for Component", nullptr,
-		                           ImGuiWindowFlags_AlwaysAutoResize)) {
+		if (ImGui::BeginPopupModal(
+		        "Search for Component", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
 			if (m_showComponentSearch) {
 				m_showComponentSearch = false;
 			}
@@ -239,8 +239,11 @@ void BoardView::Update() {
 	if (m_file && m_board && m_pinSelected) {
 		auto pin = m_pinSelected;
 		ImGui::Text("Part: %s   Pin: %d   Net: %s   Probe: %d   (%s.)",
-		            pin->component->name.c_str(), pin->number, pin->net->name.c_str(),
-		            pin->net->number, pin->component->mount_type_str().c_str());
+		            pin->component->name.c_str(),
+		            pin->number,
+		            pin->net->name.c_str(),
+		            pin->net->number,
+		            pin->component->mount_type_str().c_str());
 	}
 	ImGui::End();
 	ImGui::PopStyleVar();
@@ -399,8 +402,7 @@ void BoardView::HandleInput() {
 
 			float zoom = 0.3f;
 			// We don't apply speed modifier to I or O as Ctrl+O clashes with Open
-			if (!ImGui::IsKeyPressed('I'))
-				zoom *= speed;
+			if (!ImGui::IsKeyPressed('I')) zoom *= speed;
 
 			ChangeZoom(target, zoom);
 		}
@@ -414,8 +416,7 @@ void BoardView::HandleInput() {
 			target.y *= 0.5f;
 
 			float zoom = -0.3f;
-			if (!ImGui::IsKeyPressed('O'))
-				zoom *= speed;
+			if (!ImGui::IsKeyPressed('O')) zoom *= speed;
 
 			ChangeZoom(target, zoom);
 		}
@@ -501,8 +502,7 @@ inline void BoardView::DrawOutline(ImDrawList *draw) {
 	for (int i = 0; i < outline.size() - 1; i++) {
 		Point &pa = *outline[i];
 		Point &pb = *outline[i + 1];
-		if (pa.x == pb.x && pa.y == pb.y)
-			continue;
+		if (pa.x == pb.x && pa.y == pb.y) continue;
 		ImVec2 spa = CoordToScreen(pa.x, pa.y);
 		ImVec2 spb = CoordToScreen(pb.x, pb.y);
 		draw->AddLine(spa, spb, m_colors.boardOutline);
@@ -521,11 +521,9 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 		// continue if pin is not visible anyway
 		ImVec2 pos = CoordToScreen(pin->position.x, pin->position.y);
 		{
-			if (!ElementIsVisible(p_pin))
-				continue;
+			if (!ElementIsVisible(p_pin)) continue;
 
-			if (!IsVisibleScreen(pos.x, pos.y, psz, io))
-				continue;
+			if (!IsVisibleScreen(pos.x, pos.y, psz, io)) continue;
 		}
 
 		// color & text depending on app state & pin type
@@ -541,8 +539,7 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 			if (!pin->net || pin->type == Pin::kPinTypeNotConnected) {
 				color = m_colors.pinNotConnected;
 			} else {
-				if (pin->net->is_ground)
-					color = m_colors.pinGround;
+				if (pin->net->is_ground) color = m_colors.pinGround;
 			}
 
 			if (PartIsHighlighted(*pin->component)) {
@@ -583,17 +580,14 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 			draw->ChannelsSetCurrent(kChannelImages);
 
 			segments = trunc(psz);
-			if (segments < 8)
-				segments = 8;
-			if (segments > 32)
-				segments = 32;
+			if (segments < 8) segments = 8;
+			if (segments > 32) segments = 32;
 
 			switch (pin->type) {
-			case Pin::kPinTypeTestPad:
-				draw->AddCircleFilled(ImVec2(pos.x, pos.y), psz, color, segments);
-				break;
-			default:
-				draw->AddCircle(ImVec2(pos.x, pos.y), psz, color, segments);
+				case Pin::kPinTypeTestPad:
+					draw->AddCircleFilled(ImVec2(pos.x, pos.y), psz, color, segments);
+					break;
+				default: draw->AddCircle(ImVec2(pos.x, pos.y), psz, color, segments);
 			}
 
 			if (show_text) {
@@ -605,7 +599,8 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 				draw->AddRectFilled(
 				    ImVec2(pos_adj.x - 2.0f, pos_adj.y - 1.0f),
 				    ImVec2(pos_adj.x + text_size.x + 2.0f, pos_adj.y + text_size.y + 1.0f),
-				    m_colors.backgroundColor, 3.0f);
+				    m_colors.backgroundColor,
+				    3.0f);
 				draw->ChannelsSetCurrent(kChannelText);
 				draw->AddText(pos_adj, text_color, pin_number);
 			}
@@ -619,11 +614,9 @@ inline void BoardView::DrawParts(ImDrawList *draw) {
 	for (auto &part : m_board->Components()) {
 		auto p_part = part.get();
 
-		if (!ElementIsVisible(p_part))
-			continue;
+		if (!ElementIsVisible(p_part)) continue;
 
-		if (part->is_dummy())
-			continue;
+		if (part->is_dummy()) continue;
 
 		// scale box around pins
 		float min_x = part->pins[0]->position.x;
@@ -669,8 +662,7 @@ inline void BoardView::DrawParts(ImDrawList *draw) {
 		if (PartIsHighlighted(*part) && !part->is_dummy() && !part->name.empty()) {
 			ImVec2 text_size = ImGui::CalcTextSize(part->name.c_str());
 			float top_y = min.y;
-			if (max.y < top_y)
-				top_y = max.y;
+			if (max.y < top_y) top_y = max.y;
 			ImVec2 pos = ImVec2((min.x + max.x) * 0.5f, top_y);
 			if (bb_y_resized) {
 				pos.y -= text_size.y + 2.0f * psz;
@@ -681,7 +673,8 @@ inline void BoardView::DrawParts(ImDrawList *draw) {
 			draw->ChannelsSetCurrent(kChannelPolylines);
 			draw->AddRectFilled(ImVec2(pos.x - 2.0f, pos.y - 1.0f),
 			                    ImVec2(pos.x + text_size.x + 2.0f, pos.y + text_size.y + 1.0f),
-			                    m_colors.backgroundColor, 3.0f);
+			                    m_colors.backgroundColor,
+			                    3.0f);
 			draw->ChannelsSetCurrent(kChannelText);
 			draw->AddText(pos, m_colors.partTextColor, part->name.c_str());
 		}
@@ -689,8 +682,7 @@ inline void BoardView::DrawParts(ImDrawList *draw) {
 }
 
 void BoardView::DrawBoard() {
-	if (!m_file || !m_board)
-		return;
+	if (!m_file || !m_board) return;
 
 	ImDrawList *draw = ImGui::GetWindowDrawList();
 	if (!m_needsRedraw) {
@@ -736,14 +728,10 @@ void BoardView::SetFile(BRDFile *file) {
 	int min_x = 1000000, max_x = 0, min_y = 1000000, max_y = 0;
 	for (int i = 0; i < m_file->num_format; i++) {
 		BRDPoint &pa = m_file->format[i];
-		if (pa.x < min_x)
-			min_x = pa.x;
-		if (pa.y < min_y)
-			min_y = pa.y;
-		if (pa.x > max_x)
-			max_x = pa.x;
-		if (pa.y > max_y)
-			max_y = pa.y;
+		if (pa.x < min_x) min_x = pa.x;
+		if (pa.y < min_y) min_y = pa.y;
+		if (pa.x > max_x) max_x = pa.x;
+		if (pa.y > max_y) max_y = pa.y;
 	}
 
 	m_mx = (float)(min_x + max_x) / 2.0f;
@@ -773,36 +761,32 @@ ImVec2 BoardView::CoordToScreen(float x, float y, float w) {
 	float tx = side * m_scale * (x + w * (m_dx - m_mx));
 	float ty = -1.0f * m_scale * (y + w * (m_dy - m_my));
 	switch (m_rotation) {
-	case 0:
-		return ImVec2(tx, ty);
-	case 1:
-		return ImVec2(-ty, tx);
-	case 2:
-		return ImVec2(-tx, -ty);
-	default:
-		return ImVec2(ty, -tx);
+		case 0: return ImVec2(tx, ty);
+		case 1: return ImVec2(-ty, tx);
+		case 2: return ImVec2(-tx, -ty);
+		default: return ImVec2(ty, -tx);
 	}
 }
 
 ImVec2 BoardView::ScreenToCoord(float x, float y, float w) {
 	float tx, ty;
 	switch (m_rotation) {
-	case 0:
-		tx = x;
-		ty = y;
-		break;
-	case 1:
-		tx = y;
-		ty = -x;
-		break;
-	case 2:
-		tx = -x;
-		ty = -y;
-		break;
-	default:
-		tx = -y;
-		ty = x;
-		break;
+		case 0:
+			tx = x;
+			ty = y;
+			break;
+		case 1:
+			tx = y;
+			ty = -x;
+			break;
+		case 2:
+			tx = -x;
+			ty = -y;
+			break;
+		default:
+			tx = -y;
+			ty = x;
+			break;
 	}
 	float side = m_current_side ? -1.0f : 1.0f;
 	float invscale = 1.0f / m_scale;
@@ -853,14 +837,11 @@ void BoardView::SetTarget(float x, float y) {
 }
 
 inline bool BoardView::ElementIsVisible(const BoardElement *element) {
-	if (!element)
-		return true; // no component? => no board side info
+	if (!element) return true; // no component? => no board side info
 
-	if (element->board_side == kBoardSideBoth)
-		return true;
+	if (element->board_side == kBoardSideBoth) return true;
 
-	if (element->board_side == m_current_side)
-		return true;
+	if (element->board_side == m_current_side) return true;
 
 	return false;
 }
@@ -876,16 +857,14 @@ bool BoardView::PartIsHighlighted(const Component &component) {
 	bool highlighted = contains(component, m_partHighlighted);
 
 	// is any pin of this part selected?
-	if (m_pinSelected)
-		highlighted |= m_pinSelected->component == &component;
+	if (m_pinSelected) highlighted |= m_pinSelected->component == &component;
 
 	return highlighted;
 }
 
 void BoardView::SetNetFilter(const char *net) {
 	strcpy(m_netFilter, net);
-	if (!m_file || !m_board)
-		return;
+	if (!m_file || !m_board) return;
 
 	m_pinHighlighted.clear();
 	m_partHighlighted.clear();
@@ -910,8 +889,7 @@ void BoardView::SetNetFilter(const char *net) {
 		}
 
 		if (m_pinHighlighted.size() > 0) {
-			if (!any_visible)
-				FlipBoard();
+			if (!any_visible) FlipBoard();
 			m_pinSelected = nullptr;
 		}
 	}
@@ -920,8 +898,7 @@ void BoardView::SetNetFilter(const char *net) {
 }
 
 void BoardView::FindComponent(const char *name) {
-	if (!m_file || !m_board)
-		return;
+	if (!m_file || !m_board) return;
 
 	m_pinHighlighted.clear();
 	m_partHighlighted.clear();
@@ -942,8 +919,7 @@ void BoardView::FindComponent(const char *name) {
 		}
 
 		if (part_found) {
-			if (!any_visible)
-				FlipBoard();
+			if (!any_visible) FlipBoard();
 			m_pinSelected = nullptr;
 
 			for (auto &pin : part_found->pins) {

--- a/src/NetList.cpp
+++ b/src/NetList.cpp
@@ -6,8 +6,7 @@ NetList::NetList(TcharStringCallback cbNetSelected) {
 	cbNetSelected_ = cbNetSelected;
 }
 
-NetList::~NetList() {
-}
+NetList::~NetList() {}
 
 void NetList::Draw(const char *title, bool *p_open, Board *board) {
 	// TODO: export / fix dimensions & behaviour
@@ -32,7 +31,8 @@ void NetList::Draw(const char *title, bool *p_open, Board *board) {
 		string net_name = "";
 		for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++) {
 			net_name = nets[i]->name;
-			if (ImGui::Selectable(net_name.c_str(), selected == i,
+			if (ImGui::Selectable(net_name.c_str(),
+			                      selected == i,
 			                      ImGuiSelectableFlags_SpanAllColumns |
 			                          ImGuiSelectableFlags_AllowDoubleClick)) {
 				selected = i;

--- a/src/PartList.cpp
+++ b/src/PartList.cpp
@@ -6,8 +6,7 @@ PartList::PartList(TcharStringCallback cbNetSelected) {
 	cbNetSelected_ = cbNetSelected;
 }
 
-PartList::~PartList() {
-}
+PartList::~PartList() {}
 
 void PartList::Draw(const char *title, bool *p_open, Board *board) {
 	// TODO: export / fix dimensions & behaviour
@@ -33,8 +32,8 @@ void PartList::Draw(const char *title, bool *p_open, Board *board) {
 		for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++) {
 			part_name = parts[i]->name;
 
-			if (ImGui::Selectable(part_name.c_str(), selected == i,
-			                      ImGuiSelectableFlags_AllowDoubleClick)) {
+			if (ImGui::Selectable(
+			        part_name.c_str(), selected == i, ImGuiSelectableFlags_AllowDoubleClick)) {
 				selected = i;
 				if (ImGui::IsMouseDoubleClicked(0)) {
 					cbNetSelected_(part_name.c_str());

--- a/src/imgui_impl_dx9.cpp
+++ b/src/imgui_impl_dx9.cpp
@@ -41,8 +41,7 @@ struct CUSTOMVERTEX {
 void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 	// Avoid rendering when minimized
 	ImGuiIO &io = ImGui::GetIO();
-	if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f)
-		return;
+	if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f) return;
 
 	// Create and grow buffers if needed
 	if (!g_pVB || g_VertexBufferSize < draw_data->TotalVtxCount) {
@@ -51,9 +50,12 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 			g_pVB = NULL;
 		}
 		g_VertexBufferSize = draw_data->TotalVtxCount + 5000;
-		if (g_pd3dDevice->CreateVertexBuffer(
-		        g_VertexBufferSize * sizeof(CUSTOMVERTEX), D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY,
-		        D3DFVF_CUSTOMVERTEX, D3DPOOL_DEFAULT, &g_pVB, NULL) < 0)
+		if (g_pd3dDevice->CreateVertexBuffer(g_VertexBufferSize * sizeof(CUSTOMVERTEX),
+		                                     D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY,
+		                                     D3DFVF_CUSTOMVERTEX,
+		                                     D3DPOOL_DEFAULT,
+		                                     &g_pVB,
+		                                     NULL) < 0)
 			return;
 	}
 	if (!g_pIB || g_IndexBufferSize < draw_data->TotalIdxCount) {
@@ -62,25 +64,31 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 			g_pIB = NULL;
 		}
 		g_IndexBufferSize = draw_data->TotalIdxCount + 10000;
-		if (g_pd3dDevice->CreateIndexBuffer(
-		        g_IndexBufferSize * sizeof(ImDrawIdx), D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY,
-		        sizeof(ImDrawIdx) == 2 ? D3DFMT_INDEX16 : D3DFMT_INDEX32, D3DPOOL_DEFAULT, &g_pIB,
-		        NULL) < 0)
+		if (g_pd3dDevice->CreateIndexBuffer(g_IndexBufferSize * sizeof(ImDrawIdx),
+		                                    D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY,
+		                                    sizeof(ImDrawIdx) == 2 ? D3DFMT_INDEX16
+		                                                           : D3DFMT_INDEX32,
+		                                    D3DPOOL_DEFAULT,
+		                                    &g_pIB,
+		                                    NULL) < 0)
 			return;
 	}
 
 	// Backup the DX9 state
 	IDirect3DStateBlock9 *d3d9_state_block = NULL;
-	if (g_pd3dDevice->CreateStateBlock(D3DSBT_ALL, &d3d9_state_block) < 0)
-		return;
+	if (g_pd3dDevice->CreateStateBlock(D3DSBT_ALL, &d3d9_state_block) < 0) return;
 
 	// Copy and convert all vertices into a single contiguous buffer
 	CUSTOMVERTEX *vtx_dst;
 	ImDrawIdx *idx_dst;
-	if (g_pVB->Lock(0, (UINT)(draw_data->TotalVtxCount * sizeof(CUSTOMVERTEX)), (void **)&vtx_dst,
+	if (g_pVB->Lock(0,
+	                (UINT)(draw_data->TotalVtxCount * sizeof(CUSTOMVERTEX)),
+	                (void **)&vtx_dst,
 	                D3DLOCK_DISCARD) < 0)
 		return;
-	if (g_pIB->Lock(0, (UINT)(draw_data->TotalIdxCount * sizeof(ImDrawIdx)), (void **)&idx_dst,
+	if (g_pIB->Lock(0,
+	                (UINT)(draw_data->TotalIdxCount * sizeof(ImDrawIdx)),
+	                (void **)&idx_dst,
 	                D3DLOCK_DISCARD) < 0)
 		return;
 	for (int n = 0; n < draw_data->CmdListsCount; n++) {
@@ -134,12 +142,39 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 	// DirectX::XMMatrixIdentity()/DirectX::XMMatrixOrthographicOffCenterLH()
 	{
 		const float L = 0.5f, R = io.DisplaySize.x + 0.5f, T = 0.5f, B = io.DisplaySize.y + 0.5f;
-		D3DMATRIX mat_identity = {{1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
-		                           0.0f, 0.0f, 0.0f, 0.0f, 1.0f}};
+		D3DMATRIX mat_identity = {{1.0f,
+		                           0.0f,
+		                           0.0f,
+		                           0.0f,
+		                           0.0f,
+		                           1.0f,
+		                           0.0f,
+		                           0.0f,
+		                           0.0f,
+		                           0.0f,
+		                           1.0f,
+		                           0.0f,
+		                           0.0f,
+		                           0.0f,
+		                           0.0f,
+		                           1.0f}};
 		D3DMATRIX mat_projection = {
-		    2.0f / (R - L), 0.0f, 0.0f, 0.0f, 0.0f, 2.0f / (T - B),    0.0f,
-		    0.0f,           0.0f, 0.0f, 0.5f, 0.0f, (L + R) / (L - R), (T + B) / (B - T),
-		    0.5f,           1.0f,
+		    2.0f / (R - L),
+		    0.0f,
+		    0.0f,
+		    0.0f,
+		    0.0f,
+		    2.0f / (T - B),
+		    0.0f,
+		    0.0f,
+		    0.0f,
+		    0.0f,
+		    0.5f,
+		    0.0f,
+		    (L + R) / (L - R),
+		    (T + B) / (B - T),
+		    0.5f,
+		    1.0f,
 		};
 		g_pd3dDevice->SetTransform(D3DTS_WORLD, &mat_identity);
 		g_pd3dDevice->SetTransform(D3DTS_VIEW, &mat_identity);
@@ -156,12 +191,17 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 			if (pcmd->UserCallback) {
 				pcmd->UserCallback(cmd_list, pcmd);
 			} else {
-				const RECT r = {(LONG)pcmd->ClipRect.x, (LONG)pcmd->ClipRect.y,
-				                (LONG)pcmd->ClipRect.z, (LONG)pcmd->ClipRect.w};
+				const RECT r = {(LONG)pcmd->ClipRect.x,
+				                (LONG)pcmd->ClipRect.y,
+				                (LONG)pcmd->ClipRect.z,
+				                (LONG)pcmd->ClipRect.w};
 				g_pd3dDevice->SetTexture(0, (LPDIRECT3DTEXTURE9)pcmd->TextureId);
 				g_pd3dDevice->SetScissorRect(&r);
-				g_pd3dDevice->DrawIndexedPrimitive(D3DPT_TRIANGLELIST, vtx_offset, 0,
-				                                   (UINT)cmd_list->VtxBuffer.size(), idx_offset,
+				g_pd3dDevice->DrawIndexedPrimitive(D3DPT_TRIANGLELIST,
+				                                   vtx_offset,
+				                                   0,
+				                                   (UINT)cmd_list->VtxBuffer.size(),
+				                                   idx_offset,
 				                                   pcmd->ElemCount / 3);
 			}
 			idx_offset += pcmd->ElemCount;
@@ -177,44 +217,29 @@ void ImGui_ImplDX9_RenderDrawLists(ImDrawData *draw_data) {
 IMGUI_API LRESULT ImGui_ImplDX9_WndProcHandler(HWND, UINT msg, WPARAM wParam, LPARAM lParam) {
 	ImGuiIO &io = ImGui::GetIO();
 	switch (msg) {
-	case WM_LBUTTONDOWN:
-		io.MouseDown[0] = true;
-		return true;
-	case WM_LBUTTONUP:
-		io.MouseDown[0] = false;
-		return true;
-	case WM_RBUTTONDOWN:
-		io.MouseDown[1] = true;
-		return true;
-	case WM_RBUTTONUP:
-		io.MouseDown[1] = false;
-		return true;
-	case WM_MBUTTONDOWN:
-		io.MouseDown[2] = true;
-		return true;
-	case WM_MBUTTONUP:
-		io.MouseDown[2] = false;
-		return true;
-	case WM_MOUSEWHEEL:
-		io.MouseWheel += GET_WHEEL_DELTA_WPARAM(wParam) > 0 ? +1.0f : -1.0f;
-		return true;
-	case WM_MOUSEMOVE:
-		io.MousePos.x = (signed short)(lParam);
-		io.MousePos.y = (signed short)(lParam >> 16);
-		return true;
-	case WM_KEYDOWN:
-		if (wParam < 256)
-			io.KeysDown[wParam] = 1;
-		return true;
-	case WM_KEYUP:
-		if (wParam < 256)
-			io.KeysDown[wParam] = 0;
-		return true;
-	case WM_CHAR:
-		// You can also use ToAscii()+GetKeyboardState() to retrieve characters.
-		if (wParam > 0 && wParam < 0x10000)
-			io.AddInputCharacter((unsigned short)wParam);
-		return true;
+		case WM_LBUTTONDOWN: io.MouseDown[0] = true; return true;
+		case WM_LBUTTONUP: io.MouseDown[0] = false; return true;
+		case WM_RBUTTONDOWN: io.MouseDown[1] = true; return true;
+		case WM_RBUTTONUP: io.MouseDown[1] = false; return true;
+		case WM_MBUTTONDOWN: io.MouseDown[2] = true; return true;
+		case WM_MBUTTONUP: io.MouseDown[2] = false; return true;
+		case WM_MOUSEWHEEL:
+			io.MouseWheel += GET_WHEEL_DELTA_WPARAM(wParam) > 0 ? +1.0f : -1.0f;
+			return true;
+		case WM_MOUSEMOVE:
+			io.MousePos.x = (signed short)(lParam);
+			io.MousePos.y = (signed short)(lParam >> 16);
+			return true;
+		case WM_KEYDOWN:
+			if (wParam < 256) io.KeysDown[wParam] = 1;
+			return true;
+		case WM_KEYUP:
+			if (wParam < 256) io.KeysDown[wParam] = 0;
+			return true;
+		case WM_CHAR:
+			// You can also use ToAscii()+GetKeyboardState() to retrieve characters.
+			if (wParam > 0 && wParam < 0x10000) io.AddInputCharacter((unsigned short)wParam);
+			return true;
 	}
 	return 0;
 }
@@ -223,10 +248,8 @@ bool ImGui_ImplDX9_Init(void *hwnd, IDirect3DDevice9 *device) {
 	g_hWnd = (HWND)hwnd;
 	g_pd3dDevice = device;
 
-	if (!QueryPerformanceFrequency((LARGE_INTEGER *)&g_TicksPerSecond))
-		return false;
-	if (!QueryPerformanceCounter((LARGE_INTEGER *)&g_Time))
-		return false;
+	if (!QueryPerformanceFrequency((LARGE_INTEGER *)&g_TicksPerSecond)) return false;
+	if (!QueryPerformanceCounter((LARGE_INTEGER *)&g_Time)) return false;
 
 	ImGuiIO &io = ImGui::GetIO();
 	io.KeyMap[ImGuiKey_Tab] = VK_TAB; // Keyboard mapping. ImGui will use those indices to peek into
@@ -276,15 +299,21 @@ static bool ImGui_ImplDX9_CreateFontsTexture() {
 
 	// Upload texture to graphics system
 	g_FontTexture = NULL;
-	if (g_pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8,
-	                                D3DPOOL_DEFAULT, &g_FontTexture, NULL) < 0)
+	if (g_pd3dDevice->CreateTexture(width,
+	                                height,
+	                                1,
+	                                D3DUSAGE_DYNAMIC,
+	                                D3DFMT_A8R8G8B8,
+	                                D3DPOOL_DEFAULT,
+	                                &g_FontTexture,
+	                                NULL) < 0)
 		return false;
 	D3DLOCKED_RECT tex_locked_rect;
-	if (g_FontTexture->LockRect(0, &tex_locked_rect, NULL, 0) != D3D_OK)
-		return false;
+	if (g_FontTexture->LockRect(0, &tex_locked_rect, NULL, 0) != D3D_OK) return false;
 	for (int y = 0; y < height; y++)
 		memcpy((unsigned char *)tex_locked_rect.pBits + tex_locked_rect.Pitch * y,
-		       pixels + (width * bytes_per_pixel) * y, (width * bytes_per_pixel));
+		       pixels + (width * bytes_per_pixel) * y,
+		       (width * bytes_per_pixel));
 	g_FontTexture->UnlockRect(0);
 
 	// Store our identifier
@@ -294,16 +323,13 @@ static bool ImGui_ImplDX9_CreateFontsTexture() {
 }
 
 bool ImGui_ImplDX9_CreateDeviceObjects() {
-	if (!g_pd3dDevice)
-		return false;
-	if (!ImGui_ImplDX9_CreateFontsTexture())
-		return false;
+	if (!g_pd3dDevice) return false;
+	if (!ImGui_ImplDX9_CreateFontsTexture()) return false;
 	return true;
 }
 
 void ImGui_ImplDX9_InvalidateDeviceObjects() {
-	if (!g_pd3dDevice)
-		return;
+	if (!g_pd3dDevice) return;
 	if (g_pVB) {
 		g_pVB->Release();
 		g_pVB = NULL;
@@ -320,8 +346,7 @@ void ImGui_ImplDX9_InvalidateDeviceObjects() {
 }
 
 void ImGui_ImplDX9_NewFrame() {
-	if (!g_FontTexture)
-		ImGui_ImplDX9_CreateDeviceObjects();
+	if (!g_FontTexture) ImGui_ImplDX9_CreateDeviceObjects();
 
 	ImGuiIO &io = ImGui::GetIO();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,10 +6,10 @@
 #include "imgui_impl_dx9.h"
 #include <d3d9.h>
 #define DIRECTINPUT_VERSION 0x0800
-#include <dinput.h>
-#include <tchar.h>
 #include "crtdbg.h"
 #include "platform.h"
+#include <dinput.h>
+#include <tchar.h>
 
 // Data
 static LPDIRECT3DDEVICE9 g_pd3dDevice = NULL;
@@ -17,28 +17,24 @@ static D3DPRESENT_PARAMETERS g_d3dpp;
 
 extern LRESULT ImGui_ImplDX9_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-	if (ImGui_ImplDX9_WndProcHandler(hWnd, msg, wParam, lParam))
-		return true;
+	if (ImGui_ImplDX9_WndProcHandler(hWnd, msg, wParam, lParam)) return true;
 
 	switch (msg) {
-	case WM_SIZE:
-		if (g_pd3dDevice != NULL && wParam != SIZE_MINIMIZED) {
-			ImGui_ImplDX9_InvalidateDeviceObjects();
-			g_d3dpp.BackBufferWidth = LOWORD(lParam);
-			g_d3dpp.BackBufferHeight = HIWORD(lParam);
-			HRESULT hr = g_pd3dDevice->Reset(&g_d3dpp);
-			if (hr == D3DERR_INVALIDCALL)
-				IM_ASSERT(0);
-			ImGui_ImplDX9_CreateDeviceObjects();
-		}
-		return 0;
-	case WM_SYSCOMMAND:
-		if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu
+		case WM_SIZE:
+			if (g_pd3dDevice != NULL && wParam != SIZE_MINIMIZED) {
+				ImGui_ImplDX9_InvalidateDeviceObjects();
+				g_d3dpp.BackBufferWidth = LOWORD(lParam);
+				g_d3dpp.BackBufferHeight = HIWORD(lParam);
+				HRESULT hr = g_pd3dDevice->Reset(&g_d3dpp);
+				if (hr == D3DERR_INVALIDCALL) IM_ASSERT(0);
+				ImGui_ImplDX9_CreateDeviceObjects();
+			}
 			return 0;
-		break;
-	case WM_DESTROY:
-		PostQuitMessage(0);
-		return 0;
+		case WM_SYSCOMMAND:
+			if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu
+				return 0;
+			break;
+		case WM_DESTROY: PostQuitMessage(0); return 0;
 	}
 	return DefWindowProc(hWnd, msg, wParam, lParam);
 }
@@ -65,9 +61,17 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	                 class_name,
 	                 NULL};
 	RegisterClassEx(&wc);
-	HWND hwnd =
-	    CreateWindow(class_name, _T("Open Board Viewer"), WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
-	                 CW_USEDEFAULT, 1280, 800, NULL, NULL, wc.hInstance, NULL);
+	HWND hwnd = CreateWindow(class_name,
+	                         _T("Open Board Viewer"),
+	                         WS_OVERLAPPEDWINDOW,
+	                         CW_USEDEFAULT,
+	                         CW_USEDEFAULT,
+	                         1280,
+	                         800,
+	                         NULL,
+	                         NULL,
+	                         wc.hInstance,
+	                         NULL);
 
 	DragAcceptFiles(hwnd, true);
 
@@ -87,8 +91,12 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	g_d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
 
 	// Create the D3DDevice
-	if (pD3D->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, hwnd,
-	                       D3DCREATE_HARDWARE_VERTEXPROCESSING, &g_d3dpp, &g_pd3dDevice) < 0) {
+	if (pD3D->CreateDevice(D3DADAPTER_DEFAULT,
+	                       D3DDEVTYPE_HAL,
+	                       hwnd,
+	                       D3DCREATE_HARDWARE_VERTEXPROCESSING,
+	                       &g_d3dpp,
+	                       &g_pd3dDevice) < 0) {
 		pD3D->Release();
 		UnregisterClass(class_name, wc.hInstance);
 		MessageBox(hwnd, L"Failed to create Direct3D device", NULL, 0);
@@ -102,14 +110,18 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	io.IniFilename = NULL; // Disable imgui.ini
 
 	// Load Fonts
-	for (auto name : {"Liberation Sans", "DejaVu Sans", "Arial",
+	for (auto name : {"Liberation Sans",
+	                  "DejaVu Sans",
+	                  "Arial",
 	                  ""}) { // Empty string = use system default font
 		ImFontConfig font_cfg{};
 		font_cfg.FontDataOwnedByAtlas = false;
 		const std::vector<char> ttf = load_font(name);
 		if (!ttf.empty()) {
 			io.Fonts->AddFontFromMemoryTTF(
-			    const_cast<void *>(reinterpret_cast<const void *>(ttf.data())), ttf.size(), 20.0f,
+			    const_cast<void *>(reinterpret_cast<const void *>(ttf.data())),
+			    ttf.size(),
+			    20.0f,
 			    &font_cfg);
 			break;
 		}
@@ -211,7 +223,10 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			TCHAR filename[MAX_PATH + 10];
 
 			// Convert character encoding if required, and format the window title
-			mbstowcs_s(NULL, filename, _countof(filename), app.m_lastFileOpenName,
+			mbstowcs_s(NULL,
+			           filename,
+			           _countof(filename),
+			           app.m_lastFileOpenName,
 			           strlen(app.m_lastFileOpenName));
 			_stprintf_s(title, _countof(title), L"%s - Open Board Viewer", filename);
 
@@ -222,9 +237,10 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 		g_pd3dDevice->SetRenderState(D3DRS_ZENABLE, false);
 		g_pd3dDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, false);
 		g_pd3dDevice->SetRenderState(D3DRS_SCISSORTESTENABLE, false);
-		D3DCOLOR clear_col_dx =
-		    D3DCOLOR_RGBA((int)(clear_col.x * 255.0f), (int)(clear_col.y * 255.0f),
-		                  (int)(clear_col.z * 255.0f), (int)(clear_col.w * 255.0f));
+		D3DCOLOR clear_col_dx = D3DCOLOR_RGBA((int)(clear_col.x * 255.0f),
+		                                      (int)(clear_col.y * 255.0f),
+		                                      (int)(clear_col.z * 255.0f),
+		                                      (int)(clear_col.w * 255.0f));
 		g_pd3dDevice->Clear(0, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, clear_col_dx, 1.0f, 0);
 		if (g_pd3dDevice->BeginScene() >= 0) {
 			ImGui::Render();
@@ -234,10 +250,8 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	}
 
 	ImGui_ImplDX9_Shutdown();
-	if (g_pd3dDevice)
-		g_pd3dDevice->Release();
-	if (pD3D)
-		pD3D->Release();
+	if (g_pd3dDevice) g_pd3dDevice->Release();
+	if (pD3D) pD3D->Release();
 	UnregisterClass(class_name, wc.hInstance);
 
 	DragAcceptFiles(hwnd, false);

--- a/src/platform_unix.cpp
+++ b/src/platform_unix.cpp
@@ -3,19 +3,19 @@
 #define _CRT_SECURE_NO_WARNINGS 1
 #include "platform.h"
 #include "imgui.h"
-#include <iostream>
-#include <fstream>
-#include <stdint.h>
 #include <assert.h>
+#include <fstream>
+#include <iostream>
+#include <stdint.h>
 
 #ifndef __APPLE__
 #include <fontconfig/fontconfig.h>
 #include <gtk/gtk.h>
-#endif  // ! __APPLE__
+#endif // ! __APPLE__
 
 char *file_as_buffer(size_t *buffer_size, const char *utf8_filename) {
 	std::ifstream file;
-	file.open(utf8_filename,  std::ios::in | std::ios::binary | std::ios::ate);
+	file.open(utf8_filename, std::ios::in | std::ios::binary | std::ios::ate);
 	if (!file.is_open()) {
 		std::cerr << "Error opening " << utf8_filename << ": " << strerror(errno) << std::endl;
 		*buffer_size = 0;
@@ -40,17 +40,18 @@ char *show_file_picker() {
 	char *path = nullptr;
 	GtkWidget *parent, *dialog;
 
-	if (!gtk_init_check(NULL, NULL))
-		return nullptr;
+	if (!gtk_init_check(NULL, NULL)) return nullptr;
 
 	parent = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
- 	dialog = gtk_file_chooser_dialog_new( "Open File",
-					GTK_WINDOW(parent),
-					GTK_FILE_CHOOSER_ACTION_OPEN,
-					"_Cancel", GTK_RESPONSE_CANCEL,
-					"_Open", GTK_RESPONSE_ACCEPT,
-					NULL );
+	dialog = gtk_file_chooser_dialog_new("Open File",
+	                                     GTK_WINDOW(parent),
+	                                     GTK_FILE_CHOOSER_ACTION_OPEN,
+	                                     "_Cancel",
+	                                     GTK_RESPONSE_CANCEL,
+	                                     "_Open",
+	                                     GTK_RESPONSE_ACCEPT,
+	                                     NULL);
 
 	/* Filter file types */
 	GtkFileFilter *filter1 = gtk_file_filter_new();
@@ -67,11 +68,11 @@ char *show_file_picker() {
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 		char *filename = nullptr;
 
- 		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
 		size_t len = strlen(filename);
-		path = (char *)malloc(len+1);
-		memcpy(path, filename, len+1);
-		if (!path ) {
+		path = (char *)malloc(len + 1);
+		memcpy(path, filename, len + 1);
+		if (!path) {
 			g_free(filename);
 			gtk_widget_destroy(dialog);
 			return nullptr;
@@ -79,13 +80,11 @@ char *show_file_picker() {
 		g_free(filename);
 	}
 
-	while (gtk_events_pending())
-		gtk_main_iteration();
+	while (gtk_events_pending()) gtk_main_iteration();
 
 	gtk_widget_destroy(dialog);
 
- 	while (gtk_events_pending())
- 		gtk_main_iteration();
+	while (gtk_events_pending()) gtk_main_iteration();
 
 	return path;
 }
@@ -113,7 +112,8 @@ const std::string get_font_path(const std::string &name) {
 		     !FcStrCmpIgnoreCase(fcname, fcfamily)) // Empty name means searching for default font,
 		                                            // otherwise make sure the returned font is
 		                                            // exactly what we searched for
-		    && FcPatternGetString(font, FC_FILE, 0, &fcpath) == FcResultMatch)
+		    &&
+		    FcPatternGetString(font, FC_FILE, 0, &fcpath) == FcResultMatch)
 			path = std::string(reinterpret_cast<char *>(fcpath));
 		FcPatternDestroy(font);
 	}

--- a/src/platform_win32.cpp
+++ b/src/platform_win32.cpp
@@ -43,8 +43,13 @@ char *wide_to_utf8(const wchar_t *s) {
 
 char *file_as_buffer(size_t *buffer_size, const char *utf8_filename) {
 	wchar_t *wide_filename = utf8_to_wide(utf8_filename);
-	HANDLE file = CreateFile(wide_filename, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-	                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	HANDLE file = CreateFile(wide_filename,
+	                         GENERIC_READ,
+	                         FILE_SHARE_READ | FILE_SHARE_WRITE,
+	                         NULL,
+	                         OPEN_EXISTING,
+	                         FILE_ATTRIBUTE_NORMAL,
+	                         NULL);
 	free(wide_filename);
 	if (file == INVALID_HANDLE_VALUE) {
 		*buffer_size = 0;
@@ -103,8 +108,9 @@ const std::vector<char> load_font(const std::string &name) {
 		::GetTextFaceW(hdc, ncount, fname);
 
 		if (!name.empty() &&
-		    ::CompareStringEx(NULL, NORM_IGNORECASE, wname, name.size(), fname, ncount - 1, NULL,
-		                      NULL, 0) != CSTR_EQUAL) { // We didn't get the font we requested
+		    ::CompareStringEx(
+		        NULL, NORM_IGNORECASE, wname, name.size(), fname, ncount - 1, NULL, NULL, 0) !=
+		        CSTR_EQUAL) { // We didn't get the font we requested
 			free(wname);
 			return data;
 		}

--- a/src/resource.h
+++ b/src/resource.h
@@ -1,5 +1,5 @@
-# pragma once
+#pragma once
 
 // These mirror the Windows .rc definitions:
-#define ASSET_FIRA_SANS      109
-#define IDI_ICON1            111
+#define ASSET_FIRA_SANS 109
+#define IDI_ICON1 111


### PR DESCRIPTION
I've made some **adjustments to the clang-format** file. See the diff for the effect of these changes. Hopefully this should make a few people less frustrated with the current formatting.
- Tidy up: Added comments and grouped options in .clang-format
- Allow short statements to occupy a single line
  - e.g. `if (true) return false;` is now allowed.
- Set case lables to be indented within the switch statement.
- Set grouped assignment and operators to be aligned.
- Align line escapes as far left as possible (rather than at column
  100)
- Bracheted arguments will each have their own line if they cannot
  fit together on one line. They will also align after the opening
  bracket.

---

If there is anything you would like changing I recomend reading through the [cmake-format docs](http://clang.llvm.org/docs/ClangFormatStyleOptions.html) to get an idea of the options and then use `clang-format -i -style=file src/*.{h,cpp}` and `git diff` to see the changes. You can use `git reset --hard` to remove all changes since the last commit.

There are a number of useful clang-format tools; the main binary shown above, a git extension (`git clang-format -h`) useful for only formatting uncommitted changes , vim extension (`Ctrl+K`) and probably a plugin for whatever editor you use. An editorconfig plugin is also useful to have your editor show tabs as intended.

You can find the tools on the [LLVM svn repo](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/); the main binary is usually also included in distro packages.
