### PR TITLE
Attempt to fix situation where parts appear on both sides

### DIFF
--- a/src/openboardview/BRDBoard.cpp
+++ b/src/openboardview/BRDBoard.cpp
@@ -87,14 +87,19 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 			if (is_prefix(kComponentDummyName, comp->name)) comp->component_type = Component::kComponentTypeDummy;
 
 			// check what side the board is on (sorcery?)
-			if (brd_part.type < 8 && brd_part.type >= 4) {
+			if (
+					(brd_part.type == 1)
+					||(brd_part.type >= 4 && brd_part.type < 8)) {
 				comp->board_side = kBoardSideTop;
-			} else if (brd_part.type >= 8) {
+			} else if (
+					(brd_part.type == 2)
+					||(brd_part.type >= 8)
+					) {
 				comp->board_side = kBoardSideBottom;
 			} else {
-				comp->board_side = kBoardSideBoth; // ???
+				comp->board_side = kBoardSideBoth;
 			}
-
+					 
 			comp->mount_type = (brd_part.type & 0xc) ? Component::kMountTypeSMD : Component::kMountTypeDIP;
 
 			components_.push_back(comp);


### PR DESCRIPTION
Some BRD files have part type set as 1/2 to represent top/bottom respectively.  This merge brings the fix in to master.