### PR TITLE
Added single-parameter file load mode so that associated filenames/types

### DIFF
--- a/src/openboardview/main_opengl.cpp
+++ b/src/openboardview/main_opengl.cpp
@@ -90,6 +90,21 @@ char help[] =
 int parse_parameters(int argc, char **argv, struct globals *g) {
 	int param;
 
+
+	/*
+	 * When we're using file-associations, the OS usually just
+	 * passes the filename to be loaded as the single initial
+	 * parameter, so in this special case situation we see if the
+	 * single param is a valid file, and try load it.
+	 */
+	if (argc == 2) {
+		if( access( argv[1], F_OK ) != -1 ) {
+			g->input_file = argv[1];
+			return 0;
+		}
+	}
+
+
 	/**
 	 * Decode the input parameters.
 	 * Yes, I know, I should do this using gnu params etc.


### PR DESCRIPTION
can be loaded in Windows by the double-click method (without this fix it won't work by default because OBV expects -i <file>