### PR TITLE
CMake: OBV_BUILD as a build option and use PROJECT_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,28 +13,34 @@ if(DEFINED ENV{TERM})
 endif()
 
 # Build info
-execute_process(
-	COMMAND git rev-list HEAD --count
-	OUTPUT_VARIABLE GIT_REVISION
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-execute_process(
-	COMMAND git name-rev --name-only HEAD
-	OUTPUT_VARIABLE GIT_BRANCH
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-execute_process(
-	COMMAND git config branch.${GIT_BRANCH}.remote
-	OUTPUT_VARIABLE GIT_REMOTE
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-execute_process(
-	COMMAND git config remote.${GIT_REMOTE}.url
-	OUTPUT_VARIABLE GIT_URL
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-string(REGEX REPLACE ".*/(.+)/.+$" "\\1" GIT_REPO "${GIT_URL}") # Extract the user from a Github repo URL
-set(OBV_BUILD "R${GIT_REVISION} ${GIT_REPO}/${GIT_BRANCH}")
+if (NOT DEFINED "${OBV_BUILD}")
+	if(EXISTS "${PROJECT_SOURCE_DIR}/.git/")
+		execute_process(
+			COMMAND git rev-list HEAD --count
+			OUTPUT_VARIABLE GIT_REVISION
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		execute_process(
+			COMMAND git name-rev --name-only HEAD
+			OUTPUT_VARIABLE GIT_BRANCH
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		execute_process(
+			COMMAND git config branch.${GIT_BRANCH}.remote
+			OUTPUT_VARIABLE GIT_REMOTE
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		execute_process(
+			COMMAND git config remote.${GIT_REMOTE}.url
+			OUTPUT_VARIABLE GIT_URL
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		string(REGEX REPLACE ".*/(.+)/.+$" "\\1" GIT_REPO "${GIT_URL}") # Extract the user from a Github repo URL
+		set(OBV_BUILD "R${GIT_REVISION} ${GIT_REPO}/${GIT_BRANCH}")
+	else()
+		set (OBV_BUILD "${PROJECT_VERSION}")
+	endif()
+endif()
 message("${PROJECT_NAME} release:${CGreenB} ${OBV_BUILD}${CReset}")
 
 # GCC version check


### PR DESCRIPTION
       if there is no git

If there is no .git directory for example from a release tarball, OBV_BUILD is
set to "R". This patch should determine if git tree is present and if not use
PROJECT_VERSION as OBV_BUILD.

Also allow to set custom OBV_BUILD from command line or configuration.

Issue #79