### PR TITLE
CMake: Don't overwrite CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	endif()
 endif()
 
-# Install in project directory
-set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR})
 # Extra CMake modules (Find*.cmake) are in CMakeModules/
 set(CMAKE_MODULE_PATH
 	${CMAKE_MODULE_PATH}

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,8 @@ if [ "$1" == "--help" ]; then
 fi
 STRCOMPILE="$(tput bold ; tput setaf 2)Compiling$(tput sgr0)"
 COMPILEDIR="release_build"
-COMPILEFLAGS=""
+COMPILEFLAGS="-DCMAKE_INSTALL_PREFIX="
+export DESTDIR="$(cd "$(dirname "$0")" && pwd)"
 BUILDTYPE="$(tput bold ; tput setaf 6)release$(tput sgr0)"
 SCRIPT_ARGC=1 # number of arguments eaten by this script
 if [ "$ARG_LENGTH" -gt 0 -a "$1" == "--debug" -o "$2" == "--debug" ]; then


### PR DESCRIPTION
Common use case is to pass `DESTDIR` as a destination directory,
and `CMAKE_INSTALL_PREFIX` as a prefix:

```bash
cmake -DCMAKE_INSTALL_PREFIX=/usr
DESTDIR=/tmp/root  make install
# Not sure how DESTDIR behaves with `make package`
```

Without this change, this would result in unwanted prefix. And
there was no way of controlling install directory externally.