### PR TITLE
CPack: rpm: Don't own directories from filesystem

### DIFF
--- a/asset/CMakeLists.txt
+++ b/asset/CMakeLists.txt
@@ -22,6 +22,10 @@ elseif(UNIX)
 		"${CMAKE_CURRENT_SOURCE_DIR}/postinst" PARENT_SCOPE)
 	set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE
 		"${CMAKE_CURRENT_SOURCE_DIR}/postrm" PARENT_SCOPE)
+	set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/share/appdata
+		/usr/share/applications /usr/share/icons /usr/share/icons/hicolor
+		/usr/share/icons/hicolor/scalable /usr/share/icons/hicolor/scalable/apps
+		/usr/share/mime /usr/share/mime/packages PARENT_SCOPE)
 elseif(WIN32)
 	SET(ASSETS ${ASSETS}
 		${CMAKE_CURRENT_SOURCE_DIR}/OpenBoardView.rc


### PR DESCRIPTION
Directories excluded in this patch are owned by other packages which CPack adds automatically if not excluded. Common practice is to own only files and directories which are added by package and are not owned by other package already. Mentioned directories are in turn owned by:
`filesystem`, `hicolor-icon-theme` and `shared-mime-info` packages on Fedora. There is at least `filesystem` package on SUSE with same functionality.