### PR TITLE
Remove the dependency on bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,20 +75,20 @@ fi
 echo "$STRCOMPILE $PROJECT using $(color 4 $THREADS) $STRTHREADS ($BUILDTYPE build)"
 echo "Extra flags passed to CMake: $COMPILEFLAGS"
 cmake $COMPILEFLAGS ..
-[[ "$?" != "0" ]] && color 1 "CMAKE FAILED" && exit 1
+[ "$?" != "0" ] && color 1 "CMAKE FAILED" && exit 1
 if `echo "$COMPILEFLAGS" | grep -q "DEBUG"`; then
   make -j$THREADS install
-  [[ "$?" != "0" ]] && color 1 "MAKE INSTALL FAILED" && exit 1
+  [ "$?" != "0" ] && color 1 "MAKE INSTALL FAILED" && exit 1
 else
   make -j$THREADS install/strip
-  [[ "$?" != "0" ]] && color 1 "MAKE INSTALL/STRIP FAILED" && exit 1
+  [ "$?" != "0" ] && color 1 "MAKE INSTALL/STRIP FAILED" && exit 1
 fi
 
 case "$(uname -s)" in
   *Darwin*)
     # Generate DMG
     make package
-    [[ "$?" != "0" ]] && color 1 "MAKE PACKAGE FAILED" && exit 1
+    [ "$?" != "0" ] && color 1 "MAKE PACKAGE FAILED" && exit 1
     ;;
   *)
     # Give right execution permissions to executables

--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,8 @@ fi
 if [ ! -d $COMPILEDIR ]; then
   mkdir $COMPILEDIR
 fi
-pushd $COMPILEDIR
+LASTDIR=$PWD
+cd $COMPILEDIR
 STRTHREADS="threads"
 if [ $THREADS -eq 1 ]; then
   STRTHREADS="thread"
@@ -93,12 +94,12 @@ case "$(uname -s)" in
     ;;
   *)
     # Give right execution permissions to executables
-    popd
-    pushd bin
+    cd $LASTDIR
+    cd bin
     for i in openboardview; do chmod +x $i; done
 
     ;;
 esac
 
-popd
+cd $LASTDIR
 exit 0

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 color() {
   color="$1"

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ if [ -z $THREADS ]; then
     esac
 fi
 ARG_LENGTH=$#
-if [ "$1" == "--help" ]; then
+if [ "$1" = "--help" ]; then
   helpMsg
   exit
 fi
@@ -43,18 +43,18 @@ COMPILEFLAGS="-DCMAKE_INSTALL_PREFIX="
 export DESTDIR="$(cd "$(dirname "$0")" && pwd)"
 BUILDTYPE="$(color 6 release)"
 SCRIPT_ARGC=1 # number of arguments eaten by this script
-if [ "$ARG_LENGTH" -gt 0 -a "$1" == "--debug" -o "$2" == "--debug" ]; then
+if [ "$ARG_LENGTH" -gt 0 -a "$1" = "--debug" -o "$2" = "--debug" ]; then
   COMPILEDIR="debug_build"
   COMPILEFLAGS="$COMPILEFLAGS -DCMAKE_BUILD_TYPE=DEBUG"
   BUILDTYPE="$(color 1 debug)"
   SCRIPT_ARGC=$((SCRIPT_ARGC+1))
 fi
-if [ "$ARG_LENGTH" -gt 0 -a "$1" == "--recompile" -o "$2" == "--recompile" ]; then
+if [ "$ARG_LENGTH" -gt 0 -a "$1" = "--recompile" -o "$2" = "--recompile" ]; then
   STRCOMPILE="$(color 5 Recompiling)"
   rm -rf $COMPILEDIR
   SCRIPT_ARGC=$((SCRIPT_ARGC+1))
 fi
-if [ "$CROSS" == "mingw64" ]; then
+if [ "$CROSS" = "mingw64" ]; then
   COMPILEFLAGS="$COMPILEFLAGS -DCMAKE_TOOLCHAIN_FILE=../Toolchain-mingw64.cmake"
 fi
 COMPILEFLAGS="$COMPILEFLAGS ${@:${SCRIPT_ARGC}}" # pass other arguments to CMAKE

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,8 @@ fi
 if [ "$CROSS" = "mingw64" ]; then
   COMPILEFLAGS="$COMPILEFLAGS -DCMAKE_TOOLCHAIN_FILE=../Toolchain-mingw64.cmake"
 fi
-COMPILEFLAGS="$COMPILEFLAGS ${@:${SCRIPT_ARGC}}" # pass other arguments to CMAKE
+SUBSTRING=$(echo $@ | cut -d ' ' -f ${SCRIPT_ARGC}-)
+COMPILEFLAGS="$COMPILEFLAGS ${SUBSTRING}" # pass other arguments to CMAKE
 if [ $THREADS -lt 1 ]; then
   color 1 "Unable to detect number of threads, using 1 thread."
   THREADS=1


### PR DESCRIPTION
This allows `build.sh` to completely build OBV on systems that don't have bash, and It'll still work on systems that do. I've tested this on NetBSD 7.1, OS X 10.12.6, and Debian 8.