### PR TITLE
Warning cleanup

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -1156,7 +1156,7 @@ void BoardView::ShowInfoPane(void) {
 
 	if (m_partHighlighted.size()) {
 		ImGui::Separator();
-		ImGui::Text("%d parts selected", m_partHighlighted.size());
+		ImGui::TextUnformatted((std::to_string(m_partHighlighted.size()) + " parts selected").c_str());
 
 		for (auto part : m_partHighlighted) {
 


### PR DESCRIPTION
Some commits with no-functional-changes related on silencing strict compiler warnings.

Those warnings are often helping catching real issues in the code, and those are something we keep enabled in Blender. Not sure what is usually policy to deal with such warnings, just used Google style for that. Again, something we use in Blender and some other related projects.

Did some cleanup to help keeping my terminal outputs clean while looking in some other bug.