### PR TITLE
Fix crash when clicking on CLEAR before loading board

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -1731,7 +1731,9 @@ void BoardView::ClearAllHighlights(void) {
 	m_search[2][0]                                             = '\0';
 	m_needsRedraw                                            = true;
 	m_tooltips_enabled                                       = true;
-	for (auto part : m_board->Components()) part->visualmode = part->CVMNormal;
+	if (m_board != NULL) {
+		for (auto part : m_board->Components()) part->visualmode = part->CVMNormal;
+	}
 	m_partHighlighted.clear();
 	m_pinHighlighted.clear();
 }


### PR DESCRIPTION
Not as if it's something what people usually do, but it's easy enough to click by accident.