### PR TITLE
BRDPart::type refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ imgui.ini
 *.tags
 .idea/
 tags
+
+# Do not track QtCreator imported project files
+OpenBoardView.config
+OpenBoardView.files
+OpenBoardView.includes

--- a/src/openboardview/BRDBoard.cpp
+++ b/src/openboardview/BRDBoard.cpp
@@ -87,20 +87,15 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 			if (is_prefix(kComponentDummyName, comp->name)) comp->component_type = Component::kComponentTypeDummy;
 
 			// check what side the board is on (sorcery?)
-			if (
-					(brd_part.type == 1)
-					||(brd_part.type >= 4 && brd_part.type < 8)) {
+			if (brd_part.mounting_side == BRDPartMountingSide::Top) {
 				comp->board_side = kBoardSideTop;
-			} else if (
-					(brd_part.type == 2)
-					||(brd_part.type >= 8)
-					) {
+			} else if (brd_part.mounting_side == BRDPartMountingSide::Bottom) {
 				comp->board_side = kBoardSideBottom;
 			} else {
 				comp->board_side = kBoardSideBoth;
 			}
 					 
-			comp->mount_type = (brd_part.type & 0xc) ? Component::kMountTypeSMD : Component::kMountTypeDIP;
+			comp->mount_type = (brd_part.part_type == BRDPartType::SMD) ? Component::kMountTypeSMD : Component::kMountTypeDIP;
 
 			components_.push_back(comp);
 		}

--- a/src/openboardview/FileFormats/ASCFile.cpp
+++ b/src/openboardview/FileFormats/ASCFile.cpp
@@ -37,13 +37,14 @@ void ASCFile::parse_pin(char *&p, char *&s, char *&arena, char *&arena_end, char
 		p += 4; // Skip "Part" string
 		BRDPart part;
 
-		part.name = READ_STR();
-		char *loc = READ_STR();
+		part.name      = READ_STR();
+		part.part_type = BRDPartType::SMD;
+		char *loc      = READ_STR();
 		if (!strcmp(loc, "(T)"))
-			part.type = 10; // SMD part on top
+			part.mounting_side = BRDPartMountingSide::Top; // SMD part on top
 		else
-			part.type    = 5; // SMD part on bottom
-		part.end_of_pins = 0;
+			part.mounting_side = BRDPartMountingSide::Bottom; // SMD part on bottom
+		part.end_of_pins       = 0;
 		parts.push_back(part);
 	} else {
 		BRDPin pin;
@@ -140,7 +141,8 @@ void ASCFile::update_counts() {
 }
 
 /*
- * buf unused for now, read all files even if one of the supported *.asc was passed
+ * buf unused for now, read all files even if one of the supported *.asc was
+ * passed
  */
 ASCFile::ASCFile(std::vector<char> &buf, const std::string &filename) {
 	char *saved_locale;

--- a/src/openboardview/FileFormats/BDVFile.cpp
+++ b/src/openboardview/FileFormats/BDVFile.cpp
@@ -89,13 +89,14 @@ BDVFile::BDVFile(std::vector<char> &buf) {
 					p += 4; // Skip "Part" string
 					BRDPart part;
 
-					part.name = READ_STR();
-					char *loc = READ_STR();
+					part.name      = READ_STR();
+					part.part_type = BRDPartType::SMD;
+					char *loc      = READ_STR();
 					if (!strcmp(loc, "(T)"))
-						part.type = 10; // SMD part on top
+						part.mounting_side = BRDPartMountingSide::Top; // SMD part on top
 					else
-						part.type    = 5; // SMD part on bottom
-					part.end_of_pins = 0;
+						part.mounting_side = BRDPartMountingSide::Bottom; // SMD part on bottom
+					part.end_of_pins       = 0;
 					parts.push_back(part);
 				} else {
 					BRDPin pin;

--- a/src/openboardview/FileFormats/BRDFile.cpp
+++ b/src/openboardview/FileFormats/BRDFile.cpp
@@ -156,6 +156,7 @@ BRDFile::BRDFile(std::vector<char> &buf) {
 
 		char *p = line;
 		char *s;
+		unsigned int tmp = 0;
 
 		switch (current_block) {
 			case 2: { // var_data
@@ -174,9 +175,12 @@ BRDFile::BRDFile(std::vector<char> &buf) {
 			case 4: { // Parts
 				ENSURE(parts.size() < num_parts);
 				BRDPart part;
-				part.name        = READ_STR();
-				part.type        = READ_UINT(); // Type and layer, actually.
-				part.end_of_pins = READ_UINT();
+				part.name      = READ_STR();
+				tmp            = READ_UINT(); // Type and layer, actually.
+				part.part_type = (tmp & 0xc) ? BRDPartType::SMD : BRDPartType::ThroughHole;
+				if (tmp == 1 || (4 <= tmp && tmp < 8)) part.mounting_side = BRDPartMountingSide::Top;
+				if (tmp == 2 || (8 <= tmp)) part.mounting_side            = BRDPartMountingSide::Bottom;
+				part.end_of_pins                                          = READ_UINT();
 				ENSURE(part.end_of_pins <= num_pins);
 				parts.push_back(part);
 			} break;

--- a/src/openboardview/FileFormats/BRDFile.h
+++ b/src/openboardview/FileFormats/BRDFile.h
@@ -30,10 +30,14 @@ struct BRDPoint {
 	int y;
 };
 
+enum class BRDPartMountingSide { Both, Bottom, Top };
+enum class BRDPartType { SMD, ThroughHole };
+
 struct BRDPart {
 	const char *name;
 	std::string mfgcode;
-	unsigned int type;
+	BRDPartMountingSide mounting_side;
+	BRDPartType part_type; // SMD or TH
 	unsigned int end_of_pins;
 	BRDPoint p1{0, 0};
 	BRDPoint p2{0, 0};

--- a/src/openboardview/FileFormats/BVRFile.cpp
+++ b/src/openboardview/FileFormats/BVRFile.cpp
@@ -90,13 +90,13 @@ BVRFile::BVRFile(std::vector<char> &buf) {
 				BRDPart part;
 				BRDPin pin;
 
-				part.name = READ_STR();
-
-				char *loc = READ_STR();
+				part.name      = READ_STR();
+				part.part_type = BRDPartType::SMD;
+				char *loc      = READ_STR();
 				if (!strcmp(loc, "(T)"))
-					part.type = 10; // SMD part on top
+					part.mounting_side = BRDPartMountingSide::Top; // SMD part on top
 				else
-					part.type = 5; // SMD part on bottom
+					part.mounting_side = BRDPartMountingSide::Bottom; // SMD part on bottom
 
 				// If this is the first time we've seen this part
 				if ((strcmp(ppn, part.name))) {

--- a/src/openboardview/FileFormats/CSTFile.cpp
+++ b/src/openboardview/FileFormats/CSTFile.cpp
@@ -41,8 +41,8 @@ void CSTFile::update_counts() {
 }
 
 short read_short(char *&p) {
-	short s = *(reinterpret_cast<short*>(p));
-	p+=2;
+	short s = *(reinterpret_cast<short *>(p));
+	p += 2;
 	return s;
 }
 
@@ -78,23 +78,28 @@ CSTFile::CSTFile(std::vector<char> &buf) {
 	char *p = file_buf; // Not quite C++ but it's easier to work with a raw pointer here
 
 	num_parts = read_short(p);
-	p += 4; // New section signature
+	p += 4;                        // New section signature
 	string_length = read_short(p); // Section name length
 	read_string(p, string_length); // Section name
 
 	for (unsigned int i = 0; i < num_parts; i++) {
-		string_length = read_byte(p); // Part name length
-		char *name = read_cstring(p, string_length); // Part name
-		name[string_length] = '\0'; // Convert to C-string. Warning: overwrites the data byte just after the name in file_buf. If it's needed, copy it before this line.
-		p += 4; // unknown
+		string_length       = read_byte(p);                   // Part name length
+		char *name          = read_cstring(p, string_length); // Part name
+		name[string_length] = '\0'; // Convert to C-string. Warning: overwrites the data byte just after the name in file_buf. If
+		                            // it's needed, copy it before this line.
+		p += 4;                     // unknown
 		int layer = read_byte(p);
 
 		BRDPart part;
-		part.name = name;
-		if (layer == 0x0C) //FIXME: Layer 12
-			part.type = 10;
-		else if (layer == 0x01) // Layer 1
-			part.type = 5;
+		part.name      = name;
+		part.part_type = BRDPartType::SMD;
+		if (layer == 0x0C) {
+			// FIXME: Layer 12
+			part.mounting_side = BRDPartMountingSide::Top;
+		} else if (layer == 0x01) {
+			// Layer 1
+			part.mounting_side = BRDPartMountingSide::Bottom;
+		}
 
 		part.end_of_pins = 0;
 		parts.push_back(part);
@@ -105,23 +110,23 @@ CSTFile::CSTFile(std::vector<char> &buf) {
 	p -= 2; // begining of nets list
 	num_nets = read_short(p);
 	for (unsigned int i = 0; i < num_nets; i++) {
-		string_length = read_byte(p); // Net name length
-		p[-1] = '\0'; // Convert previous name to C-string
-		char *name = read_cstring(p, string_length); // Net name
+		string_length = read_byte(p);                   // Net name length
+		p[-1]         = '\0';                           // Convert previous name to C-string
+		char *name    = read_cstring(p, string_length); // Net name
 		nets.push_back(name);
 	}
 	p[0] = '\0'; // Convert last name to C-string
 
 	// Add dummy parts for orphan pins on both sides
 	BRDPart part;
-	part.name        = "...";
-	part.type        = 1; //FIXME: Both sides?
-	part.end_of_pins = 0;     // Unused
+	part.name          = "...";
+	part.mounting_side = BRDPartMountingSide::Both; // FIXME: Both sides?
+	part.part_type     = BRDPartType::ThroughHole;
+	part.end_of_pins   = 0; // Unused
 	parts.push_back(part);
 
-
 	while (strncmp(p, "CPad", 4)) p++; // Search for the CPad section
-	p -= 8; // Go back to begining of section header
+	p -= 8;                            // Go back to begining of section header
 
 	num_pins = read_short(p);
 	p += 10; // Skip past section header
@@ -130,13 +135,15 @@ CSTFile::CSTFile(std::vector<char> &buf) {
 		BRDPin pin;
 
 		short part_id = read_short(p); // dev_id
-		if (part_id >= 0) pin.part = part_id + 1;
-		else pin.part = parts.size(); // No associated part, use dummy
+		if (part_id >= 0)
+			pin.part = part_id + 1;
+		else
+			pin.part = parts.size(); // No associated part, use dummy
 
-		pin.probe = read_short(p); // probe? not sure
+		pin.probe    = read_short(p); // probe? not sure
 		short net_id = read_short(p); // net_id
 
-		pin.net = nets.at(net_id);
+		pin.net   = nets.at(net_id);
 		pin.pos.x = read_short(p);
 		pin.pos.y = read_short(p);
 
@@ -144,12 +151,12 @@ CSTFile::CSTFile(std::vector<char> &buf) {
 
 		pins.push_back(pin);
 
-		p += 4; //seems unused
+		p += 4; // seems unused
 	}
 
 	gen_outline(); // We haven't figured out how to get the outline yet
 
-	update_counts(); //FIXME: useless?
+	update_counts(); // FIXME: useless?
 
-	valid = true; //FIXME: better way to ensure that?
+	valid = true; // FIXME: better way to ensure that?
 }

--- a/src/openboardview/FileFormats/FZFile.cpp
+++ b/src/openboardview/FileFormats/FZFile.cpp
@@ -224,12 +224,12 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t *fzkey) {
 	char *content = FZFile::split(file_buf, buffer_size, content_size, descr, descr_size); // then split it
 
 	/*
-if (!content) {
+  if (!content) {
 	 // Decryption must have failed, so try again now without decrypting the data
 	std::copy(buf.begin(), buf.end(), file_buf);
 	content = FZFile::split(file_buf, buffer_size, content_size, descr, descr_size); // then split it
-}
-*/
+  }
+  */
 
 	ENSURE(content != nullptr);
 	ENSURE(content_size > 0);
@@ -303,11 +303,12 @@ if (!content) {
 				/*char *sname =*/READ_STR();
 				char *smirror = READ_STR();
 				/*char *srotate =*/READ_STR();
+				part.part_type = BRDPartType::SMD;
 				if (!strcmp(smirror, "YES"))
-					part.type = 10; // SMD part on top
+					part.mounting_side = BRDPartMountingSide::Top; // SMD part on top
 				else
-					part.type    = 5; // SMD part on bottom
-				part.end_of_pins = 0;
+					part.mounting_side = BRDPartMountingSide::Bottom; // SMD part on bottom
+				part.end_of_pins       = 0;
 				parts.push_back(part);
 				parts_id[part.name] = parts.size();
 			} break;


### PR DESCRIPTION
- Renamed BRDPart::type to BRDPart::mounting_side
- Introduced enum for BRDPart::mounting_side

There is a bit hardly understood-able code around the BRDBoard::BRDBoard(const BRDFile *const boardFile), what I have not touched, but I can clean it up to if required. 