### PR TITLE
Fix memory leak happening when opening file

### DIFF
--- a/src/openboardview/FileFormats/ASCFile.h
+++ b/src/openboardview/FileFormats/ASCFile.h
@@ -1,18 +1,22 @@
 #pragma once
 
 #include "BRDFile.h"
+
+#include <vector>
+
 class ASCFile : public BRDFile {
   public:
+	typedef std::vector<char *>::iterator line_iterator_t;
 	ASCFile(std::vector<char> &buf, const std::string &filename);
 	~ASCFile() {
 		free(file_buf);
 	}
 
 	//	static bool verifyFormat(std::vector<char> &buf);
-	void parse_format(char *&p, char *&s, char *&arena, char *&arena_end, char **&lines);
-	void parse_pin(char *&p, char *&s, char *&arena, char *&arena_end, char **&lines);
-	void parse_nail(char *&p, char *&s, char *&arena, char *&arena_end, char **&lines);
-	bool read_asc(const std::string &filename, void (ASCFile::*parser)(char *&, char *&, char *&, char *&, char **&));
+	void parse_format(char *&p, char *&s, char *&arena, char *&arena_end, line_iterator_t &line_it);
+	void parse_pin(char *&p, char *&s, char *&arena, char *&arena_end, line_iterator_t &line_it);
+	void parse_nail(char *&p, char *&s, char *&arena, char *&arena_end, line_iterator_t &line_it);
+	bool read_asc(const std::string &filename, void (ASCFile::*parser)(char *&, char *&, char *&, char *&, line_iterator_t&));
 	void update_counts();
 
   protected:

--- a/src/openboardview/FileFormats/BDVFile.cpp
+++ b/src/openboardview/FileFormats/BDVFile.cpp
@@ -45,29 +45,30 @@ BDVFile::BDVFile(std::vector<char> &buf) {
 
 	int current_block = 0;
 
-	char **lines = stringfile(file_buf);
-	ENSURE(lines);
+	std::vector<char *> lines;
+	stringfile(file_buf, lines);
 
-	while (*lines) {
-		char *line = *lines;
-		++lines;
+	std::vector<char *>::iterator line_it = lines.begin();
+	while (line_it != lines.end()) {
+		char *line = *line_it;
+		++line_it;
 
 		while (isspace((uint8_t)*line)) line++;
 		if (!line[0]) continue;
 		if (!strcmp(line, "<<format.asc>>")) {
 			current_block = 1;
-			lines += 8; // Skip 8 unused lines before 1st point. Might not work with
-			            // all files.
+			line_it += 8; // Skip 8 unused lines before 1st point. Might not work with
+			              // all files.
 			continue;
 		}
 		if (!strcmp(line, "<<pins.asc>>")) {
 			current_block = 2;
-			lines += 8; // Skip 8 unused lines before 1st part
+			line_it += 8; // Skip 8 unused lines before 1st part
 			continue;
 		}
 		if (!strcmp(line, "<<nails.asc>>")) {
 			current_block = 3;
-			lines += 7; // Skip 7 unused lines before 1st nail
+			line_it += 7; // Skip 7 unused lines before 1st nail
 			continue;
 		}
 

--- a/src/openboardview/FileFormats/BRD2File.cpp
+++ b/src/openboardview/FileFormats/BRD2File.cpp
@@ -32,13 +32,10 @@ BRD2File::BRD2File(std::vector<char> &buf) {
 
 	int current_block = 0;
 
-	char **lines = stringfile(file_buf);
-	ENSURE(lines)
+	std::vector<char *>  lines;
+	stringfile(file_buf, lines);
 
-	while (*lines) {
-		char *line = *lines;
-		++lines;
-
+	for (char *line : lines) {
 		while (isspace((uint8_t)*line)) line++;
 		if (!line[0]) continue;
 

--- a/src/openboardview/FileFormats/BRDFile.h
+++ b/src/openboardview/FileFormats/BRDFile.h
@@ -93,5 +93,5 @@ class BRDFile {
 	static constexpr std::array<uint8_t, 4> signature = {{0x23, 0xe2, 0x63, 0x28}};
 };
 
-char **stringfile(char *buffer);
+void stringfile(char *buffer, std::vector<char*> &lines);
 char *fix_to_utf8(char *s, char **arena, char *arena_end);

--- a/src/openboardview/FileFormats/BVRFile.cpp
+++ b/src/openboardview/FileFormats/BVRFile.cpp
@@ -43,12 +43,13 @@ BVRFile::BVRFile(std::vector<char> &buf) {
 
 	int current_block = 0;
 
-	char **lines = stringfile(file_buf);
-	ENSURE(lines);
+	std::vector<char *> lines;
+	stringfile(file_buf, lines);
 
-	while (*lines) {
-		char *line = *lines;
-		++lines;
+	std::vector<char *>::iterator line_it = lines.begin();
+	while (line_it != lines.end()) {
+		char *line = *line_it;
+		++line_it;
 
 		while (isspace((uint8_t)*line)) line++;
 		if (!line[0]) continue;
@@ -56,19 +57,19 @@ BVRFile::BVRFile(std::vector<char> &buf) {
 		if (!strcmp(line, "<<Layout>>")) {
 			//			fprintf(stderr,"HIT LAYOUT\n");
 			current_block = 1;
-			lines += 1; // Skip 1 unused lines before 1st layout
+			line_it += 1; // Skip 1 unused lines before 1st layout
 			continue;
 		}
 		if (!strcmp(line, "<<Pin>>")) {
 			current_block = 2;
 			//			fprintf(stderr,"HIT PIN, block = %d\n", current_block);
-			lines += 1; // Skip 1 unused lines before 1st pin
+			line_it += 1; // Skip 1 unused lines before 1st pin
 			continue;
 		}
 		if (!strcmp(line, "<<Nail>>")) {
 			//			fprintf(stderr,"HIT NAIL\n");
 			current_block = 3;
-			lines += 1; // Skip 1 unused lines before 1st nail
+			line_it += 1; // Skip 1 unused lines before 1st nail
 			continue;
 		}
 

--- a/src/openboardview/FileFormats/FZFile.cpp
+++ b/src/openboardview/FileFormats/FZFile.cpp
@@ -246,11 +246,11 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t *fzkey) {
 	int current_block = 0;
 	std::unordered_map<std::string, int> parts_id; // map between part name and part number
 
-	char **lines_content = stringfile(content);
-	ENSURE(lines_content);
+	std::vector<char *> lines_content;
+	stringfile(content, lines_content);
 
-	char **lines_descr = stringfile(descr);
-	ENSURE(lines_descr);
+	std::vector<char *> lines_descr;
+	stringfile(descr, lines_descr);
 
 	// For some reason, some boards have COMMAs as decimal separators. Will wonders ever cease ( I realise this is a regional thing
 	// )?
@@ -258,10 +258,7 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t *fzkey) {
 
 	// Parse the content part (parts, pins, nails)
 
-	while (*lines_content) {
-		char *line = *lines_content;
-		++lines_content;
-
+	for (char *line : lines_content) {
 		//	fprintf(stdout,"%s\n", line);
 
 		while (isspace((uint8_t)*line)) line++;
@@ -370,10 +367,9 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t *fzkey) {
 	}
 
 	// Parse the descr part (parts info)
-	lines_descr += 2; // Discard first 2 lines (board description, currently unused and table columns name)
-	while (*lines_descr) {
-		char *line = *lines_descr;
-		++lines_descr;
+	// Note: Discard first 2 lines (board description, currently unused and table columns name)
+	for (size_t i = 2; i < lines_descr.size(); ++i) {
+		char *line = lines_descr[i];
 
 		while (isspace((uint8_t)*line)) line++;
 		if (!line[0]) continue;


### PR DESCRIPTION
The issue was caused by stringfile() allocating memory for lines pointers, and
this memory was never freed (even though the comment of the function explicitly
mentioned that the result is to be freed).

This commit replaces allocation of bare memory with using std::vector to store
pointers to all lines. This saves us a trouble of manually freeing memory.

Most of the board parsers became shorter, but some of them are still using
bare pointers internally because they need to pass line pointer around and
modify it (i.e. skip lines). It is probably possible to make that code more
modern, but could happen as a separate change.