### PR TITLE
Fix crash when attempting to open directory from command line

### DIFF
--- a/src/openboardview/platform.h
+++ b/src/openboardview/platform.h
@@ -75,3 +75,26 @@ const std::string get_user_dir(const UserDir userdir);
 #ifdef _WIN32
 char *strcasestr(const char *str, const char *pattern);
 #endif // _WIN32
+
+// File stat queries, cross platform.
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#if defined(_MSC_VER) || defined(__MINGW64__)
+typedef struct _stat64 path_stat_t;
+#elif defined(__MINGW32__)
+typedef struct _stati64 path_stat_t;
+#else
+typedef struct _stat path_stat_t;
+#endif
+#ifndef S_ISDIR
+#define S_ISDIR(x) (((x) & _S_IFDIR) == _S_IFDIR)
+#endif
+#ifndef S_ISREG
+#define S_ISREG(x) (((x) & _S_IFREG) == _S_IFREG)
+#endif
+#else
+typedef struct stat path_stat_t;
+#endif
+
+int path_stat(const std::string& path, path_stat_t *st);

--- a/src/openboardview/unix.cpp
+++ b/src/openboardview/unix.cpp
@@ -241,4 +241,8 @@ const std::string get_user_dir(const UserDir userdir) {
 }
 #endif
 
+int path_stat(const std::string& path, path_stat_t *st) {
+	return stat(path.c_str(), st);
+}
+
 #endif

--- a/src/openboardview/utils.cpp
+++ b/src/openboardview/utils.cpp
@@ -17,6 +17,12 @@
 // Loads an entire file in to memory
 std::vector<char> file_as_buffer(const std::string &utf8_filename) {
 	std::vector<char> data;
+
+	if (!path_is_regular(utf8_filename)) {
+		std::cerr << "Error opening " << utf8_filename << ": not a regular file " << std::endl;
+		return data;
+	}
+
 	std::ifstream file;
 	file.open(utf8_filename, std::ios::in | std::ios::binary | std::ios::ate);
 
@@ -82,4 +88,20 @@ std::string lookup_file_insensitive(const std::string &path, const std::string &
 std::vector<std::string> split_string(const std::string str) {
 	std::istringstream iss(str);
 	return {std::istream_iterator<std::string>{iss}, std::istream_iterator<std::string>{}};
+}
+
+bool path_is_directory(const std::string &path) {
+	path_stat_t st;
+	if (path_stat(path, &st) != 0) {
+		return false;
+	}
+	return S_ISDIR(st.st_mode);
+}
+
+bool path_is_regular(const std::string &path) {
+	path_stat_t st;
+	if (path_stat(path, &st) != 0) {
+		return false;
+	}
+	return S_ISREG(st.st_mode);
 }

--- a/src/openboardview/utils.h
+++ b/src/openboardview/utils.h
@@ -21,3 +21,6 @@ std::string lookup_file_insensitive(const std::string &path, const std::string &
 
 // Split a string in a vector, delimiter is a space (stringstream iterator)
 std::vector<std::string> split_string(const std::string str);
+
+bool path_is_directory(const std::string &path);
+bool path_is_regular(const std::string &path);

--- a/src/openboardview/win32.cpp
+++ b/src/openboardview/win32.cpp
@@ -177,4 +177,20 @@ char *strcasestr(const char *str, const char *pattern) {
 	return NULL;
 }
 
+static int path_wstat(const wchar_t *wpath, path_stat_t *st) {
+#if defined(_MSC_VER) || defined(__MINGW64__)
+	return _wstat64(wpath, st);
+#elif defined(__MINGW32__)
+	return _wstati64(wpath, st);
+#else
+	return _wstat(wpath, st);
+#endif
+}
+
+int path_stat(const std::string &path, path_stat_t *st) {
+	auto u16path = utf8_to_utf16(path);
+	auto wpath = utf16_to_wchar(u16path);
+	return path_wstat(wpath, st);
+}
+
 #endif


### PR DESCRIPTION
When one tries to pass a directory instead of file name from
command line OpenBoardView will crash. This happens because
of ftell() returns -1 which is cast to unsigned value. There
will be a memory allocation error right after that.