### PR TITLE
Fix gentoo git-r3 QA warning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,5 @@
 	url = https://github.com/Dav1dde/glad.git
 [submodule "src/imgui"]
 	path = src/imgui
-	url = http://github.com/OpenBoardView/imgui
+	url = https://github.com/OpenBoardView/imgui
 	branch = master


### PR DESCRIPTION
https should be used instead of http