### PR TITLE
Only link against libdl on Linux

### DIFF
--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -154,7 +154,7 @@ else()
 		${SDL2_LIBRARIES}
 	)
 endif()
-if(NOT WIN32)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 	target_link_libraries(${PROJECT_NAME_LOWER}
 		dl
 	)

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -138,6 +138,7 @@ target_link_libraries(${PROJECT_NAME_LOWER}
 	${COCOA_LIBRARY}
 	${ZLIB_LIBRARIES}
 	${SQLITE3_LIBRARIES}
+	${CMAKE_DL_LIBS}
 )
 
 if(MINGW) # Link statically with SDL2 for Windows
@@ -152,11 +153,6 @@ else()
 	endif()
 	target_link_libraries(${PROJECT_NAME_LOWER}
 		${SDL2_LIBRARIES}
-	)
-endif()
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	target_link_libraries(${PROJECT_NAME_LOWER}
-		dl
 	)
 endif()
 


### PR DESCRIPTION
Pretty sure Linux is the only one needing `libdl`, cf.

https://linux.die.net/man/3/dlopen
https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man3/dlopen.3.html
https://www.freebsd.org/cgi/man.cgi?query=dlopen&sektion=3
https://man.openbsd.org/dlopen.3
http://netbsd.gw.com/cgi-bin/man-cgi?dlopen+3+NetBSD-current
https://www.dragonflybsd.org/cgi/web-man?command=dlopen&section=3
https://docs.oracle.com/cd/E26502_01/html/E29034/dlopen-3c.html
https://docs.oracle.com/cd/E86824_01/html/E54772/libdl-3lib.html
