### PR TITLE
Update BoardView.cpp

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -2812,8 +2812,8 @@ void BoardView::OutlineGenFillDraw(ImDrawList *draw, int ydelta, double thicknes
 	/*
 	 * Go through each scan line
 	 */
-	y = min.y;
-	while (y < max.y) {
+	y = ystart;
+	while (y < yend) {
 
 		scanhits.resize(0);
 		// scan outline segments to see if any intersect with our horizontal scan line


### PR DESCRIPTION
Long standing performance complaint as you zoomed in the system would slow down.  Caused because the correct start->end bounds for the scanline algorithm were not being correctly set.