### PR TITLE
Fix get_user_dir for Linux when XDG env var is set

### DIFF
--- a/src/openboardview/unix.cpp
+++ b/src/openboardview/unix.cpp
@@ -232,6 +232,8 @@ const std::string get_user_dir(const UserDir userdir) {
 			else if (userdir == UserDir::Data)
 				path += "/.local/share";
 		}
+	} else {
+		path += std::string(envVar);
 	}
 	if (!path.empty()) {
 		path += "/" OBV_NAME "/";


### PR DESCRIPTION
If XDG_CONFIG_HOME and XDG_DATA_HOME are set, the current directory is used because they never get added to the path.