### PR TITLE
Board outline failsafe generator

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -4012,13 +4012,16 @@ void BoardView::SetFile(BRDFile *file) {
 	delete m_file;
 	delete m_board;
 
+	// Check board outline (format) point count.
+	//		If we don't have an outline, generate one	
+	//
 	if ( file->format.size() < 3 ) {
 		auto pins  = file->pins;
 		float minx, maxx, miny, maxy;
-		float margin = 200.0f;
+		float margin = 200.0f; // #define or leave this be? Rather arbritary.
 
-		minx = miny = DBL_MAX;
-		maxx = maxy = DBL_MIN;
+		minx = miny = FLT_MAX;
+		maxx = maxy = FLT_MIN;
 
 		for (auto a: pins) {
 			if (a.pos.x > maxx) maxx = a.pos.x;
@@ -4037,7 +4040,6 @@ void BoardView::SetFile(BRDFile *file) {
 		file->format.push_back({maxx, maxy});
 		file->format.push_back({minx, maxy});
 		file->format.push_back({minx, miny});
-
 	}
 
 

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -4017,11 +4017,11 @@ void BoardView::SetFile(BRDFile *file) {
 	//
 	if ( file->format.size() < 3 ) {
 		auto pins  = file->pins;
-		float minx, maxx, miny, maxy;
-		float margin = 200.0f; // #define or leave this be? Rather arbritary.
+		int minx, maxx, miny, maxy;
+		int margin = 200; // #define or leave this be? Rather arbritary.
 
-		minx = miny = FLT_MAX;
-		maxx = maxy = FLT_MIN;
+		minx = miny = INT_MAX;
+		maxx = maxy = INT_MIN;
 
 		for (auto a: pins) {
 			if (a.pos.x > maxx) maxx = a.pos.x;

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -4012,6 +4012,35 @@ void BoardView::SetFile(BRDFile *file) {
 	delete m_file;
 	delete m_board;
 
+	if ( file->format.size() < 3 ) {
+		auto pins  = file->pins;
+		float minx, maxx, miny, maxy;
+		float margin = 200.0f;
+
+		minx = miny = DBL_MAX;
+		maxx = maxy = DBL_MIN;
+
+		for (auto a: pins) {
+			if (a.pos.x > maxx) maxx = a.pos.x;
+			if (a.pos.y > maxy) maxy = a.pos.y;
+			if (a.pos.x < minx) minx = a.pos.x;
+			if (a.pos.y < miny) miny = a.pos.y;
+		}
+
+		maxx += margin;
+		maxy += margin;
+		minx -= margin;
+		miny -= margin;
+
+		file->format.push_back({minx, miny});
+		file->format.push_back({maxx, miny});
+		file->format.push_back({maxx, maxy});
+		file->format.push_back({minx, maxy});
+		file->format.push_back({minx, miny});
+
+	}
+
+
 	m_file  = file;
 	m_board = new BRDBoard(file);
 	searcher.setParts(m_board->Components());

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -3058,6 +3058,10 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 		// continue if pin is not visible anyway
 		if (!ComponentIsVisible(pin->component)) continue;
 
+		// Check that the pin is actually visible on this side
+		//  ( testpads in particular would show up on both )
+		if (pin->board_side != m_current_side) continue;
+
 		ImVec2 pos = CoordToScreen(pin->position.x, pin->position.y);
 		{
 			if (!IsVisibleScreen(pos.x, pos.y, psz, io)) continue;


### PR DESCRIPTION
In situations where no board outline has been generated (either lack of data in the board file or parsing incompatibility),  good to have a failsafe outline generated.