### PR TITLE
Search dialog: add searching by details (part mfg code and pin names)

### DIFF
--- a/src/openboardview/Board.cpp
+++ b/src/openboardview/Board.cpp
@@ -1,0 +1,16 @@
+#include "Board.h"
+
+std::vector<const std::string *> Component::searchableStringDetails() const {
+	return {&mfgcode};
+}
+
+std::vector<const std::string *> Net::searchableStringDetails() const {
+	std::vector<const std::string *> result = {};
+	for (const auto &pin : pins) {
+		result.push_back(&pin->name);
+		if (pin->number != pin->name) {
+			result.push_back(&pin->number);
+		}
+	}
+	return result;
+}

--- a/src/openboardview/Board.h
+++ b/src/openboardview/Board.h
@@ -107,6 +107,8 @@ struct Net : BoardElement {
 	string UniqueId() const {
 		return kBoardNetPrefix + name;
 	}
+
+	std::vector<const std::string *> searchableStringDetails() const;
 };
 
 struct outline_pt {
@@ -215,6 +217,8 @@ struct Component : BoardElement {
 	string UniqueId() const {
 		return kBoardComponentPrefix + name;
 	}
+
+	std::vector<const std::string *> searchableStringDetails() const;
 };
 
 class Board {

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -1772,6 +1772,9 @@ void BoardView::SearchComponent(void) {
 			ImGui::SameLine();
 			search_params_changed |= ImGui::Checkbox("Nets", &m_searchNets);
 
+			ImGui::SameLine();
+			search_params_changed |= ImGui::Checkbox("Including details", &searcher.configSearchDetails());
+
 			ImGui::Text(" Search mode: ");
 			ImGui::SameLine();
 			if (ImGui::RadioButton("Substring", searcher.isMode(SearchMode::Sub))) {

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SOURCES
 	history.cpp
 	utils.cpp
 	BoardView.cpp
+	Board.cpp
 	BRDBoard.cpp
 	FileFormats/BRDFileBase.cpp
 	FileFormats/ADFile.cpp

--- a/src/openboardview/Searcher.cpp
+++ b/src/openboardview/Searcher.cpp
@@ -41,7 +41,14 @@ template<class T> std::vector<T> Searcher::searchFor(const std::string& search, 
 	if (search.empty()) return results;
 
 	for (auto &p : v) {
-		if (strstrModeSearch(p->name, search)) {
+		bool match = strstrModeSearch(p->name, search);
+		if (m_search_details && !match) {
+			const auto details = p->searchableStringDetails();
+			for (auto s = details.begin(); s != details.end() && !match; ++s) {
+				match |= strstrModeSearch(**s, search);
+			}
+		}
+		if (match) {
 			results.push_back(p);
 			limit--;
 		}

--- a/src/openboardview/Searcher.h
+++ b/src/openboardview/Searcher.h
@@ -8,6 +8,7 @@ enum class SearchMode {
 
 class Searcher {
 	SearchMode m_searchMode = SearchMode::Sub;
+	bool m_search_details   = false;
 
 	SharedVector<Net> m_nets;
 	SharedVector<Component> m_parts;
@@ -24,4 +25,9 @@ public:
 	SharedVector<Component> parts(const std::string& search);
 	SharedVector<Net> nets(const std::string& search, int limit);
 	SharedVector<Net> nets(const std::string& search);
+
+	bool &configSearchDetails() {
+		return m_search_details;
+	}
+
 };


### PR DESCRIPTION
The new "Including Part Number" checkbox is added to search dialog.
It enables searching the "msgcode" string attached to each element.

For me it is useful for cases like answering
"Where did they put that P-mosfet in this revision of design?"
(datasheets I'm working with has a lot of msgcode data - part number, Ohm values, even packages).

It's checkbox disabled by default,
since it's UI is a bit less expected then other searches -
the results that are showing below search fields are still names,
not msgcodes, so it is not so immediately obvious
why they are included there.

Also, I'm a not 100% sure of portability
of pointer-to-member-of-template class that I used in Searcher.cpp,
but I do not know actual problems with it.