### PR TITLE
openboardview: add "unix" X11 geometry flag handling

### DIFF
--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -147,6 +147,10 @@ target_link_libraries(${PROJECT_NAME_LOWER}
 	${CMAKE_DL_LIBS}
 )
 
+if(NOT WIN32)
+       target_link_libraries(${PROJECT_NAME_LOWER} X11)
+endif()
+
 if(MINGW) # Link statically with SDL2 for Windows
 	target_link_libraries(${PROJECT_NAME_LOWER}
 		${SDL2_STATIC_LIBRARIES}


### PR DESCRIPTION
Add the unix/linux specific X11 XParseGeometry() along with the '-g
<geometry>' flag to handle window sizing and positioning.

To get there, added 2 fields to the 'struct global', tweaked the
parse_parameters() to set the new values if provided on the command
line.

Refactored the call to SDL_CreateWindow() to always use the global
values start_x and start_y, which both now default to
SDL_WINDOWPOS_CENTERED.

Added the X11 shared library target only if not on WIN32 to
src/openboardview/CMakeLists.txt.