### PR TITLE
Copy to clipboard for component and its pins.

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -1235,6 +1235,24 @@ void BoardView::ShowInfoPane(void) {
 
 			ImGui::SameLine();
 			ImGui::Text("%ld Pin(s)", part->pins.size());
+			ImGui::SameLine();
+			{
+				char name_and_id[128];
+				snprintf(name_and_id, sizeof(name_and_id), "Copy##%s", part->name.c_str());
+				if (ImGui::SmallButton(name_and_id)) {
+					// std::string speed is no concern here, since button action is not in UI rendering loop
+					std::string to_copy = part->name;
+					if (part->mfgcode.size())
+					{
+						to_copy += " " + part->mfgcode;
+					}
+					for (auto pin : part->pins)
+					{
+						to_copy += "\n" + pin->name + " " + pin->net->name;
+					}
+					ImGui::SetClipboardText(to_copy.c_str());
+				}
+			}
 			if (part->mfgcode.size()) ImGui::TextWrapped("%s", part->mfgcode.c_str());
 
 			/*


### PR DESCRIPTION
This implements feature request #172
"Copy" small button is added to the first line of a component.
It copies multiline text, containing
reference designator (and description if present) on 1st line,
pin names and associated in a separate line for every pin