### PR TITLE
Improve ground pins handling

### DIFF
--- a/src/openboardview/BRDBoard.cpp
+++ b/src/openboardview/BRDBoard.cpp
@@ -57,8 +57,6 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 			// avoid having multiple UNCONNECTED<XXX> references
 			if (is_prefix(kNetUnconnectedPrefix, net->name)) continue;
 
-			// check whether the pin represents ground
-			net->is_ground = (net->name == "GND");
 			net->number    = brd_nail.probe;
 
 			if (brd_nail.side == 1) {
@@ -214,6 +212,8 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 
 	// Populate Net vector by using the map. (sorted by keys)
 	for (auto &net : net_map) {
+		// check whether the pin represents ground
+		net.second->is_ground = (net.second->name == "GND");
 		nets_.push_back(net.second);
 	}
 

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -3128,12 +3128,6 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 				//				draw->AddCircle(ImVec2(pos.x, pos.y), psz * pinHaloDiameter, ImColor(0xff0000ff), 32);
 			}
 
-			if (!pin->net || pin->type == Pin::kPinTypeNotConnected) {
-				color = (m_colors.pinNotConnectedColor & cmask) | omask;
-			} else {
-				if (pin->net->is_ground) color = (m_colors.pinGroundColor & cmask) | omask;
-			}
-
 			/*
 			 * If the part is selected, as part of search or otherwise
 			 */
@@ -3161,6 +3155,12 @@ inline void BoardView::DrawPins(ImDrawList *draw) {
 				draw_ring  = true;
 				show_text  = true;
 				threshold  = 0;
+			}
+
+			if (!pin->net || pin->type == Pin::kPinTypeNotConnected) {
+				color = (m_colors.pinNotConnectedColor & cmask) | omask;
+			} else {
+				if (pin->net->is_ground) color = (m_colors.pinGroundColor & cmask) | omask;
 			}
 
 			// pin is on the same net as selected pin: highlight > rest


### PR DESCRIPTION
The first commit improves ground rendering: it is rendered in distinguished color among
the set of pins highlited by belonging to the same component.

The second commit improves detection of ground pins - they weren't detected for some files