### PR TITLE
Misc patches for Haiku support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,17 +20,7 @@ EOH
 
 PROJECT="$(color 3 OpenBoardView)"
 if [ -z $THREADS ]; then
-    THREADS=1
-    case "$(uname -s)" in
-      *Darwin*|*BSD*)
-        THREADS=`sysctl -n hw.ncpu`
-        ;;
-      *)
-        if [ -r "/proc/cpuinfo" ]; then
-            THREADS=`cat /proc/cpuinfo | grep processor | wc -l`
-        fi
-        ;;
-    esac
+    THREADS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)"
 fi
 ARG_LENGTH=$#
 if [ "$1" = "--help" ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
+TPUT_B="$(tput bold)"
+TPUT_0="$(tput sgr0)"
+
 color() {
   color="$1"
   text="$2"
-  echo "$(tput bold; tput setaf ${color})${text}$(tput sgr0)"
+  echo "$TPUT_B$(tput setaf ${color})${text}$TPUT_0"
 }
 
 helpMsg() {

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(PkgConfig REQUIRED)
 			add_definitions(-DENABLE_FONTCONFIG)
 		endif()
 
-		pkg_search_module(GTK REQUIRED gtk+-3.0 gtk+-2.0) # gtk2 fallback if gtk3 not found
+		pkg_search_module(GTK gtk+-3.0 gtk+-2.0) # gtk2 fallback if gtk3 not found
 		if(GTK_FOUND)
 			message(STATUS "Found GTK version ${GTK_VERSION}")
 			link_directories(${GTK_LIBRARY_DIRS}) # not linked since we load it at runtime


### PR DESCRIPTION
These patches makes it run on Haiku.
- use more portable way to count CPU cores in build.sh
- really make GTK optional, we don't have it.
- cache some `tput` results, devices runtime by 3 in a Haiku VM. Even on Linux it devices by 5 user time.