### PR TITLE
Introduce BRDFileBase and cleanup nail handling

### DIFF
--- a/src/openboardview/BRDBoard.cpp
+++ b/src/openboardview/BRDBoard.cpp
@@ -16,7 +16,7 @@ using namespace std::placeholders;
 const string BRDBoard::kNetUnconnectedPrefix = "UNCONNECTED";
 const string BRDBoard::kComponentDummyName   = "...";
 
-BRDBoard::BRDBoard(const BRDFile *const boardFile)
+BRDBoard::BRDBoard(const BRDFileBase * const boardFile)
     : m_file(boardFile) {
 	// TODO: strip / trim all strings, especially those used as keys
 	// TODO: just loop through original arrays?
@@ -59,7 +59,7 @@ BRDBoard::BRDBoard(const BRDFile *const boardFile)
 
 			net->number    = brd_nail.probe;
 
-			if (brd_nail.side == 1) {
+			if (brd_nail.side == BRDPartMountingSide::Top) {
 				net->board_side = kBoardSideTop;
 			} else {
 				net->board_side = kBoardSideBottom;

--- a/src/openboardview/BRDBoard.h
+++ b/src/openboardview/BRDBoard.h
@@ -10,10 +10,10 @@ using namespace std;
 
 class BRDBoard : public Board {
   public:
-	BRDBoard(const BRDFile *const boardFile);
+	BRDBoard(const BRDFileBase *const boardFile);
 	~BRDBoard();
 
-	const BRDFile *m_file;
+	const BRDFileBase *m_file;
 
 	EBoardType BoardType();
 

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -4223,7 +4223,7 @@ void BoardView::CenterView(void) {
 	m_needsRedraw = true;
 }
 
-void BoardView::LoadBoard(BRDFile *file) {
+void BoardView::LoadBoard(BRDFileBase *file) {
 	delete m_board;
 
 	// Check board outline (format) point count.

--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -123,7 +123,7 @@ enum DrawChannel {
 enum FlipModes { flipModeVP = 0, flipModeMP = 1, NUM_FLIP_MODES };
 
 struct BoardView {
-	BRDFile *m_file;
+	BRDFileBase *m_file;
 	Board *m_board;
 	BackgroundImage backgroundImage{m_current_side};
 
@@ -326,7 +326,7 @@ struct BoardView {
 	void DrawParts(ImDrawList *draw);
 	void DrawBoard();
 	void DrawNetWeb(ImDrawList *draw);
-	void LoadBoard(BRDFile *file);
+	void LoadBoard(BRDFileBase *file);
 	int LoadFile(const filesystem::path &filepath);
 	ImVec2 CoordToScreen(float x, float y, float w = 1.0f);
 	ImVec2 ScreenToCoord(float x, float y, float w = 1.0f);

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
 	utils.cpp
 	BoardView.cpp
 	BRDBoard.cpp
+	FileFormats/BRDFileBase.cpp
 	FileFormats/ADFile.cpp
 	FileFormats/ASCFile.cpp
 	FileFormats/BDVFile.cpp

--- a/src/openboardview/FileFormats/ADFile.h
+++ b/src/openboardview/FileFormats/ADFile.h
@@ -1,5 +1,5 @@
-#include "BRDFile.h"
 #pragma once
+#include "BRDFile.h"
 
 struct AD_BRDNet {
 	unsigned int id;

--- a/src/openboardview/FileFormats/ADFile.h
+++ b/src/openboardview/FileFormats/ADFile.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
 struct AD_BRDNet {
 	unsigned int id;
@@ -33,11 +33,8 @@ struct AD_BRDPad {
 	const char *layer;
 };
 
-struct ADFile : public BRDFile {
+struct ADFile : public BRDFileBase {
 	ADFile(std::vector<char> &buf);
-	~ADFile() {
-		free(file_buf);
-	}
 
 	struct {
 		bool operator()(BRDPin a, BRDPin b) const {

--- a/src/openboardview/FileFormats/ASCFile.cpp
+++ b/src/openboardview/FileFormats/ASCFile.cpp
@@ -86,9 +86,9 @@ void ASCFile::parse_nail(char *&p, char *&s, char *&arena, char *&arena_end, lin
 	/*char *grid =*/READ_STR();
 	char *loc = READ_STR();
 	if (!strcmp(loc, "(T)"))
-		nail.side = 1;
+		nail.side = BRDPartMountingSide::Top;
 	else
-		nail.side = 2;
+		nail.side = BRDPartMountingSide::Bottom;
 	/*char *netid =*/READ_STR(); // uint
 	nail.net = READ_STR();
 	nails.push_back(nail);

--- a/src/openboardview/FileFormats/ASCFile.h
+++ b/src/openboardview/FileFormats/ASCFile.h
@@ -1,18 +1,15 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
 #include <vector>
 
 #include "filesystem_impl.h"
 
-class ASCFile : public BRDFile {
+class ASCFile : public BRDFileBase {
   public:
 	typedef std::vector<char *>::iterator line_iterator_t;
 	ASCFile(std::vector<char> &buf, const filesystem::path &filepath);
-	~ASCFile() {
-		free(file_buf);
-	}
 
 	//	static bool verifyFormat(std::vector<char> &buf);
 	void parse_format(char *&p, char *&s, char *&arena, char *&arena_end, line_iterator_t &line_it);

--- a/src/openboardview/FileFormats/BDVFile.cpp
+++ b/src/openboardview/FileFormats/BDVFile.cpp
@@ -133,9 +133,9 @@ BDVFile::BDVFile(std::vector<char> &buf) {
 				/*char *grid =*/READ_STR();
 				char *loc = READ_STR();
 				if (!strcmp(loc, "(T)"))
-					nail.side = 1;
+					nail.side = BRDPartMountingSide::Top;
 				else
-					nail.side = 2;
+					nail.side = BRDPartMountingSide::Bottom;
 				/*char *netid =*/READ_STR(); // uint
 				nail.net = READ_STR();
 				nails.push_back(nail);

--- a/src/openboardview/FileFormats/BDVFile.h
+++ b/src/openboardview/FileFormats/BDVFile.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
-struct BDVFile : public BRDFile {
+struct BDVFile : public BRDFileBase {
 	BDVFile(std::vector<char> &buf);
-	~BDVFile() {
-		free(file_buf);
-	}
 
 	static bool verifyFormat(std::vector<char> &buf);
 };

--- a/src/openboardview/FileFormats/BRD2File.cpp
+++ b/src/openboardview/FileFormats/BRD2File.cpp
@@ -152,7 +152,13 @@ BRD2File::BRD2File(std::vector<char> &buf) {
 					std::cerr << "Missing net id: " << netid << std::endl;
 				}
 
-				nail.side = READ_UINT();
+				bool nail_is_top = READ_UINT() == 1;
+				if (nail_is_top) {
+					nail.side = BRDPartMountingSide::Top;
+				} else {
+					nail.side = BRDPartMountingSide::Bottom;
+					nail.pos.y = max.y - nail.pos.y;
+				}
 				nails.push_back(nail);
 
 			} break;
@@ -218,21 +224,7 @@ BRD2File::BRD2File(std::vector<char> &buf) {
 		parts.push_back(part);
 	}
 
-	for (auto &nail : nails) {
-		BRDPin pin;
-		pin.pos = nail.pos;
-		if (nail.side == 1) {
-			pin.part = parts.size();
-			pin.side = BRDPinSide::Top;
-		} else {
-			pin.pos.y = max.y - pin.pos.y;
-			pin.part  = parts.size() - 1;
-			pin.side = BRDPinSide::Bottom;
-		}
-		pin.probe = nail.probe;
-		pin.net   = nail.net;
-		pins.push_back(pin);
-	}
+	AddNailsAsPins();
 
 	valid = current_block != 0;
 }

--- a/src/openboardview/FileFormats/BRD2File.h
+++ b/src/openboardview/FileFormats/BRD2File.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include "BRDFile.h"
-struct BRD2File : public BRDFile {
+#include "BRDFileBase.h"
+struct BRD2File : public BRDFileBase {
 	BRD2File(std::vector<char> &buf);
-	~BRD2File() {
-		free(file_buf);
-	}
 
 	static bool verifyFormat(std::vector<char> &buf);
 };

--- a/src/openboardview/FileFormats/BRDAllegroFile.h
+++ b/src/openboardview/FileFormats/BRDAllegroFile.h
@@ -1,15 +1,11 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
-struct BRDAllegroFile : public BRDFile {
-	BRDAllegroFile(std::vector<char> &buf) {
+struct BRDAllegroFile : public BRDFileBase {
+	BRDAllegroFile(std::vector<char> &/*buf*/) {
 		valid = false;
 		error_msg = "Allegro format is not supported. Please use Allegro® FREE Physical Viewer.";
-	}
-
-	~BRDAllegroFile() {
-		free(file_buf);
 	}
 
 	static bool verifyFormat(std::vector<char> &buf) {

--- a/src/openboardview/FileFormats/BRDFile.cpp
+++ b/src/openboardview/FileFormats/BRDFile.cpp
@@ -1,6 +1,5 @@
 #include "BRDFile.h"
 
-#include "utf8/utf8.h"
 #include "utils.h"
 #include <cctype>
 #include <stdexcept>
@@ -10,72 +9,6 @@
 
 // Header for recognizing a BRD file
 decltype(BRDFile::signature) constexpr BRDFile::signature;
-
-// from stb.h
-void stringfile(char *buffer, std::vector<char*> &lines) {
-	char *s;
-	size_t count, i;
-
-	// two passes through: first time count lines, second time set them
-	for (i = 0; i < 2; ++i) {
-		s                   = buffer;
-		if (i == 1) lines[0] = s;
-		count               = 1; // was '1',  but C arrays are 0-indexed
-		while (*s) {
-			if (*s == '\n' || *s == '\r') {
-
-				// If this is the 2nd pass, then terminate the line at the first line break char
-				if (i == 1) *s = 0;
-
-				s++; // next char
-
-				// if the termination is a CRLF combo, then jump to the next char
-				if ((*s == '\r') || (*s == '\n')) s++;
-
-				// if the char is valid (first after line break), set up the next item in the line array
-				if (*s) { // it's not over yet
-					if (i == 1) {
-						lines[count] = s;
-						//					  list[count+1] = NULL;
-						// fprintf(stdout,"%s\n",list[count]);
-					}
-					++count;
-				}
-			}
-			s++;
-		} // while s
-
-		// Generate the required array to hold all the line starting points
-		if (i == 0) {
-			lines.resize(count);
-		}
-	}
-}
-
-char *fix_to_utf8(char *s, char **arena, char *arena_end) {
-	if (!utf8valid(s)) {
-		return s;
-	}
-	char *p     = *arena;
-	char *begin = p;
-	while (*s) {
-		uint32_t c = (uint8_t)*s;
-		if (c < 0x80) {
-			if (p + 1 >= arena_end) goto done;
-			*p++ = c;
-		} else {
-			if (p + 2 >= arena_end) goto done;
-			*p++ = 0xc0 | (c >> 6);
-			*p++ = 0x80 | (c & 0x3f);
-		}
-		++s;
-	}
-	if (p + 1 >= arena_end) goto done;
-	*p++ = 0;
-done:
-	*arena = p;
-	return begin;
-}
 
 /*
  * Returns true if the file format seems to be BRD.
@@ -196,7 +129,7 @@ BRDFile::BRDFile(std::vector<char> &buf) {
 				nail.probe = READ_UINT();
 				nail.pos.x = READ_INT();
 				nail.pos.y = READ_INT();
-				nail.side  = READ_UINT();
+				nail.side  = READ_UINT() == 1 ? BRDPartMountingSide::Top : BRDPartMountingSide::Bottom;
 				nail.net   = READ_STR();
 				nails.push_back(nail);
 			} break;

--- a/src/openboardview/FileFormats/BRDFile.h
+++ b/src/openboardview/FileFormats/BRDFile.h
@@ -1,98 +1,17 @@
 #pragma once
+#include "BRDFileBase.h"
 
 #include <array>
 #include <cstdlib>
-#include <string>
+#include <cstdint>
 #include <vector>
 
-#define READ_INT() strtol(p, &p, 10);
-// Warning: read as int then cast to uint if positive
-#define READ_UINT                                \
-	[&]() {                                      \
-		int value = strtol(p, &p, 10);           \
-		ENSURE(value >= 0, error_msg);           \
-		return static_cast<unsigned int>(value); \
-	}
-#define READ_DOUBLE() strtod(p, &p);
-#define READ_STR                                     \
-	[&]() {                                          \
-		while ((*p) && (isspace((uint8_t)*p))) ++p;  \
-		s = p;                                       \
-		while ((*p) && (!isspace((uint8_t)*p))) ++p; \
-		*p = 0;                                      \
-		p++;                                         \
-		return fix_to_utf8(s, &arena, arena_end);    \
-	}
-
-struct BRDPoint {
-	int x;
-	int y;
-
-	bool operator==(const BRDPoint& point) {
-		return x == point.x && y == point.y;
-	}
-	bool operator!=(const BRDPoint& point) {
-		return x != point.x || y != point.y;
-	}
-};
-
-enum class BRDPartMountingSide { Both, Bottom, Top };
-enum class BRDPartType { SMD, ThroughHole };
-
-struct BRDPart {
-	const char *name;
-	std::string mfgcode;
-	BRDPartMountingSide mounting_side;
-	BRDPartType part_type; // SMD or TH
-	unsigned int end_of_pins;
-	BRDPoint p1{0, 0};
-	BRDPoint p2{0, 0};
-};
-
-enum class BRDPinSide { Both, Bottom, Top };
-
-struct BRDPin {
-	BRDPoint pos;
-	int probe;
-	unsigned int part;
-	BRDPinSide side;
-	const char *net;
-	double radius    = 0.5f;
-	const char *snum = nullptr;
-	const char *name = nullptr;
-
-	bool operator<(const BRDPin &p) const // For sorting the vector
-	{
-		return part == p.part ? (std::string(snum) < std::string(p.snum)) : (part < p.part); // sort by part number then pin number
-	}
-};
-
-struct BRDNail {
-	unsigned int probe;
-	BRDPoint pos;
-	unsigned int side;
-	const char *net;
-};
-
-class BRDFile {
+class BRDFile : public BRDFileBase {
   public:
-	unsigned int num_format = 0;
-	unsigned int num_parts  = 0;
-	unsigned int num_pins   = 0;
-	unsigned int num_nails  = 0;
-
-	std::vector<BRDPoint> format;
-	std::vector<BRDPart> parts;
-	std::vector<BRDPin> pins;
-	std::vector<BRDNail> nails;
-
 	char *file_buf = nullptr;
 
-	bool valid = false;
-	std::string error_msg = "";
-
 	BRDFile(std::vector<char> &buf);
-	BRDFile(){};
+	BRDFile(){}
 	~BRDFile() {
 		free(file_buf);
 	}
@@ -102,6 +21,3 @@ class BRDFile {
   private:
 	static constexpr std::array<uint8_t, 4> signature = {{0x23, 0xe2, 0x63, 0x28}};
 };
-
-void stringfile(char *buffer, std::vector<char*> &lines);
-char *fix_to_utf8(char *s, char **arena, char *arena_end);

--- a/src/openboardview/FileFormats/BRDFile.h
+++ b/src/openboardview/FileFormats/BRDFile.h
@@ -8,13 +8,7 @@
 
 class BRDFile : public BRDFileBase {
   public:
-	char *file_buf = nullptr;
-
 	BRDFile(std::vector<char> &buf);
-	BRDFile(){}
-	~BRDFile() {
-		free(file_buf);
-	}
 
 	static bool verifyFormat(std::vector<char> &buf);
 

--- a/src/openboardview/FileFormats/BRDFileBase.cpp
+++ b/src/openboardview/FileFormats/BRDFileBase.cpp
@@ -1,0 +1,90 @@
+#include "BRDFileBase.h"
+
+#include "utf8/utf8.h"
+#include <cstdint>
+
+// from stb.h
+void stringfile(char *buffer, std::vector<char*> &lines) {
+	char *s;
+	size_t count, i;
+
+	// two passes through: first time count lines, second time set them
+	for (i = 0; i < 2; ++i) {
+		s                   = buffer;
+		if (i == 1) lines[0] = s;
+		count               = 1; // was '1',  but C arrays are 0-indexed
+		while (*s) {
+			if (*s == '\n' || *s == '\r') {
+
+				// If this is the 2nd pass, then terminate the line at the first line break char
+				if (i == 1) *s = 0;
+
+				s++; // next char
+
+				// if the termination is a CRLF combo, then jump to the next char
+				if ((*s == '\r') || (*s == '\n')) s++;
+
+				// if the char is valid (first after line break), set up the next item in the line array
+				if (*s) { // it's not over yet
+					if (i == 1) {
+						lines[count] = s;
+						//					  list[count+1] = NULL;
+						// fprintf(stdout,"%s\n",list[count]);
+					}
+					++count;
+				}
+			}
+			s++;
+		} // while s
+
+		// Generate the required array to hold all the line starting points
+		if (i == 0) {
+			lines.resize(count);
+		}
+	}
+}
+
+char *fix_to_utf8(char *s, char **arena, char *arena_end) {
+	if (!utf8valid(s)) {
+		return s;
+	}
+	char *p     = *arena;
+	char *begin = p;
+	while (*s) {
+		uint32_t c = (uint8_t)*s;
+		if (c < 0x80) {
+			if (p + 1 >= arena_end) goto done;
+			*p++ = c;
+		} else {
+			if (p + 2 >= arena_end) goto done;
+			*p++ = 0xc0 | (c >> 6);
+			*p++ = 0x80 | (c & 0x3f);
+		}
+		++s;
+	}
+	if (p + 1 >= arena_end) goto done;
+	*p++ = 0;
+done:
+	*arena = p;
+	return begin;
+}
+
+void BRDFileBase::AddNailsAsPins() {
+	for (auto &nail : nails) {
+		BRDPin pin;
+		pin.pos = nail.pos;
+		if (nail.side == BRDPartMountingSide::Both) {
+			pin.part = parts.size();
+			pin.side = BRDPinSide::Both;
+		} else if (nail.side == BRDPartMountingSide::Top) {
+			pin.part = parts.size();
+			pin.side = BRDPinSide::Top;
+		} else {
+			pin.part  = parts.size() - 1;
+			pin.side = BRDPinSide::Bottom;
+		}
+		pin.probe = nail.probe;
+		pin.net   = nail.net;
+		pins.push_back(pin);
+	}
+}

--- a/src/openboardview/FileFormats/BRDFileBase.h
+++ b/src/openboardview/FileFormats/BRDFileBase.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#define READ_INT() strtol(p, &p, 10);
+// Warning: read as int then cast to uint if positive
+#define READ_UINT                                \
+	[&]() {                                      \
+		int value = strtol(p, &p, 10);           \
+		ENSURE(value >= 0, error_msg);           \
+		return static_cast<unsigned int>(value); \
+	}
+#define READ_DOUBLE() strtod(p, &p)
+#define READ_STR                                     \
+	[&]() {                                          \
+		while ((*p) && (isspace((uint8_t)*p))) ++p;  \
+		s = p;                                       \
+		while ((*p) && (!isspace((uint8_t)*p))) ++p; \
+		*p = 0;                                      \
+		p++;                                         \
+		return fix_to_utf8(s, &arena, arena_end);    \
+	}
+
+struct BRDPoint {
+	// mil (thou) is used here
+	int x = 0;
+	int y = 0;
+
+	bool operator==(const BRDPoint& point) {
+		return x == point.x && y == point.y;
+	}
+	bool operator!=(const BRDPoint& point) {
+		return x != point.x || y != point.y;
+	}
+};
+
+enum class BRDPartMountingSide { Both, Bottom, Top };
+enum class BRDPartType { SMD, ThroughHole };
+
+struct BRDPart {
+	const char *name = nullptr;
+	std::string mfgcode;
+	BRDPartMountingSide mounting_side{};
+	BRDPartType part_type{}; // SMD or TH
+	unsigned int end_of_pins = 0;
+	BRDPoint p1{0, 0};
+	BRDPoint p2{0, 0};
+};
+
+enum class BRDPinSide { Both, Bottom, Top };
+
+struct BRDPin {
+	BRDPoint pos;
+	int probe = 0;
+	unsigned int part = 0;
+	BRDPinSide side{};
+	const char *net = nullptr;
+	double radius    = 0.5f;
+	const char *snum = nullptr;
+	const char *name = nullptr;
+
+	bool operator<(const BRDPin &p) const // For sorting the vector
+	{
+		return part == p.part ? (std::string(snum) < std::string(p.snum)) : (part < p.part); // sort by part number then pin number
+	}
+};
+
+struct BRDNail {
+	unsigned int probe = 0;
+	BRDPoint pos;
+	BRDPartMountingSide side{};
+	const char *net = nullptr;
+};
+
+class BRDFileBase {
+  public:
+	unsigned int num_format = 0;
+	unsigned int num_parts  = 0;
+	unsigned int num_pins   = 0;
+	unsigned int num_nails  = 0;
+
+	std::vector<BRDPoint> format;
+	std::vector<BRDPart> parts;
+	std::vector<BRDPin> pins;
+	std::vector<BRDNail> nails;
+
+	bool valid = false;
+	std::string error_msg = "";
+
+	void AddNailsAsPins();
+	BRDFileBase() {}
+	~BRDFileBase() {}
+};
+
+void stringfile(char *buffer, std::vector<char*> &lines);
+char *fix_to_utf8(char *s, char **arena, char *arena_end);

--- a/src/openboardview/FileFormats/BRDFileBase.h
+++ b/src/openboardview/FileFormats/BRDFileBase.h
@@ -88,9 +88,17 @@ class BRDFileBase {
 	bool valid = false;
 	std::string error_msg = "";
 
+	virtual ~BRDFileBase()
+	{
+		free(file_buf);
+		file_buf = nullptr;
+	}
+  protected:
 	void AddNailsAsPins();
 	BRDFileBase() {}
-	~BRDFileBase() {}
+	// file_buf is used by some implementations. But since the derived class constructurs
+	// are already passed a memory buffer most usages are "historic unneeded extra copies".
+	char *file_buf = nullptr;
 };
 
 void stringfile(char *buffer, std::vector<char*> &lines);

--- a/src/openboardview/FileFormats/BVR3File.h
+++ b/src/openboardview/FileFormats/BVR3File.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
-struct BVR3File : public BRDFile {
+struct BVR3File : public BRDFileBase {
 	BVR3File(std::vector<char> &buf);
-	~BVR3File() {
-		free(file_buf);
-	}
 
 	static bool verifyFormat(std::vector<char> &buf);
 };

--- a/src/openboardview/FileFormats/BVRFile.cpp
+++ b/src/openboardview/FileFormats/BVRFile.cpp
@@ -138,9 +138,9 @@ BVRFile::BVRFile(std::vector<char> &buf) {
 				/*char *grid =*/READ_STR();
 				char *loc = READ_STR();
 				if (!strcmp(loc, "(T)"))
-					nail.side = 1;
+					nail.side = BRDPartMountingSide::Top;
 				else
-					nail.side = 2;
+					nail.side = BRDPartMountingSide::Bottom;
 
 				/*char *netid =*/READ_STR();
 				nail.net   = READ_STR();

--- a/src/openboardview/FileFormats/BVRFile.h
+++ b/src/openboardview/FileFormats/BVRFile.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
-struct BVRFile : public BRDFile {
+struct BVRFile : public BRDFileBase {
 	BVRFile(std::vector<char> &buf);
-	~BVRFile() {
-		free(file_buf);
-	}
 
 	static bool verifyFormat(std::vector<char> &buf);
 };

--- a/src/openboardview/FileFormats/CADFile.cpp
+++ b/src/openboardview/FileFormats/CADFile.cpp
@@ -146,7 +146,7 @@ CADFile::CADFile(std::vector<char> &buf) {
 				double posy  = READ_DOUBLE();
 				nail.pos.y   = posy * multiplier;
 				/*STR        =*/READ_STR();
-				nail.side    = READ_DOUBLE();
+				nail.side    = READ_DOUBLE() == 1 ? BRDPartMountingSide::Top : BRDPartMountingSide::Bottom;
 				/*double     =*/READ_DOUBLE();
 				nails.push_back(nail);
 			} break;

--- a/src/openboardview/FileFormats/CADFile.h
+++ b/src/openboardview/FileFormats/CADFile.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
-struct CADFile : public BRDFile {
+struct CADFile : public BRDFileBase {
 	CADFile(std::vector<char> &buf);
-	~CADFile() {
-		free(file_buf);
-	}
 	enum Block {
 		Invalid,
 		None,

--- a/src/openboardview/FileFormats/CSTFile.h
+++ b/src/openboardview/FileFormats/CSTFile.h
@@ -1,13 +1,10 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
 
-class CSTFile : public BRDFile {
+class CSTFile : public BRDFileBase {
   public:
 	CSTFile(std::vector<char> &buf);
-	~CSTFile() {
-		free(file_buf);
-	}
 
   private:
 	void gen_outline();

--- a/src/openboardview/FileFormats/FZFile.cpp
+++ b/src/openboardview/FileFormats/FZFile.cpp
@@ -394,9 +394,9 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t fzkey[44]) {
 				nail.pos.y  = posy * multiplier;
 				char *loc   = READ_STR();
 				if (!strcmp(loc, "T"))
-					nail.side = 1; // on top
+					nail.side = BRDPartMountingSide::Top;
 				else
-					nail.side = 2; // on bottom
+					nail.side = BRDPartMountingSide::Bottom;
 				/*double radius =*/READ_DOUBLE();
 				nails.push_back(nail);
 			} break;

--- a/src/openboardview/FileFormats/FZFile.h
+++ b/src/openboardview/FileFormats/FZFile.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "BRDFile.h"
+#include "BRDFileBase.h"
+#include <array>
 
 #undef READ_INT
 #undef READ_UINT
@@ -63,12 +64,9 @@ struct FZPartDesc {
 	const char *partno2;
 };
 
-class FZFile : public BRDFile {
+class FZFile : public BRDFileBase {
   public:
 	FZFile(std::vector<char> &buf, uint32_t fzkey[44]);
-	~FZFile() {
-		free(file_buf);
-	}
 
 	void SetKey(char *keytext);
 


### PR DESCRIPTION
Preparations before introducing gencad format:
* Separate specific BRDFile implementation from common base class BRDFileBase.
* Utilize BRDPartMountingSide for the nails side marking
* Factor out Nails-as-pins conversion to a method of BRDFileBase from specific BRD2 implementation.