### PR TITLE
Improved interactive update of search-preview-highlighted parts.

### DIFF
--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -254,6 +254,7 @@ struct BoardView {
 	char m_cachedDrawList[sizeof(ImDrawList)];
 	ImVector<char> m_cachedDrawCommands;
 	SharedVector<Net> m_nets;
+	int m_active_search_column = 0;
 	char m_search[3][128];
 	char m_netFilter[128];
 	std::string m_lastFileOpenName;
@@ -333,6 +334,7 @@ struct BoardView {
 	// void Move(float x, float y);
 	void Rotate(int count);
 	void DrawSelectedPins(ImDrawList *draw);
+	void ResetSearch();
 	void ClearAllHighlights(void);
 
 	// Sets the center of the screen to (x,y) in board space


### PR DESCRIPTION
On clicking checkboxes/radiobuttons:
- added immediate update of search preview by currently focused column
- removed resetting of focused search column to first.
(search column is kept while changing searching parameters by storing its index in m_active_search_column)

On changing search column:
- added immediate update of highlighted parts (search preview by currently focused column).
- so tabbing from first column with text to the second empty column immediately clears preview.

On clearing text inside search column:
- added clearing of search preview. Before this patch the preview showed the results just before the clearing.

On opening popup again after performing search with Enter:
- added immediate previewing of text kept from previous search
- the focused column is kept, not reset to the first