### PR TITLE
GenCAD THT pins support

### DIFF
--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -213,6 +213,9 @@ bool GenCADFile::parse_components() {
 						bool mirror_y         = has_text_content(mirror_ast, "MIRRORY");
 						brd_part.part_type    = is_shape_smd(shape_ast) ? BRDPartType::SMD : BRDPartType::ThroughHole;
 						parse_shape_pins_to_component(&brd_part, component_rotation_angle, mirror_x, mirror_y, shape_ast);
+						if ( brd_part.part_type == BRDPartType::ThroughHole ) {
+							brd_part.mounting_side = BRDPartMountingSide::Both;
+						}
 						brd_part.end_of_pins = num_pins - 1;
 					}
 				}

--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -248,13 +248,14 @@ bool GenCADFile::parse_shape_pins_to_component(
 				if (pos_ast && pin_name_ast) {
 					BRDPin pin;
 					pin.radius = 0.5;
-					// enable the code below once the pin.radius will be processed
-					/*mpc_ast_t *padstack_name_ast = mpc_ast_get_child(pin_ast, "pad_name|nonquoted_string|regex");
+					mpc_ast_t *padstack_name_ast = mpc_ast_get_child(pin_ast, "pad_name|nonquoted_string|regex");
+					mpc_ast_t *padstack_ast = 0;
 					if (padstack_name_ast) {
-					    mpc_ast_t *padstack_ast = get_padstack_by_name(padstack_name_ast->contents);
-					    if (padstack_ast)
-					        pin.radius = get_padstack_radius(padstack_ast);
-					}*/
+						padstack_ast = get_padstack_by_name(padstack_name_ast->contents);
+						// enable the code below once the pin.radius will be processed
+						//if (padstack_ast)
+						//	pin.radius = get_padstack_radius(padstack_ast);
+					}
 
 					// part is not yet added to the list at this point
 					pin.part  = static_cast<unsigned int>(parts.size() + 1);
@@ -274,7 +275,9 @@ bool GenCADFile::parse_shape_pins_to_component(
 						pin.net = tmp;
 						nc_counter++;
 					}
-					if (part->mounting_side == BRDPartMountingSide::Top) {
+					if (padstack_ast && !is_padstack_smd(padstack_ast)) {
+						pin.side = BRDPinSide::Both;
+					} else if (part->mounting_side == BRDPartMountingSide::Top) {
 						pin.side = BRDPinSide::Top;
 					} else {
 						pin.side = BRDPinSide::Bottom;


### PR DESCRIPTION
673a43d5c265e441e21ac684053b0a133e5a88dc makes pins marked as through-hole visible on both sides, but for unknown to me reason those pins cannot be selected with a mouse click on the other side of the board. Not sure if bug or doing something wrong. The same issue occurs with landrex `*.brd` files.

9d000d84c45955cb4f0e85cdb322e1d2e9f17699 is a workaround for this issue which additionally creates extra clutter on screen by duplicating component outline on both sides. (but THT pads can be selected on either side now). Would be for the best if this commit wasn't needed/merged and underlying issue was fixed.

This feature seems to be distinct enough and requires a lot of testing so I have put it as separate from #247 pull request

Lack of this feature is especially noticeable in devel/evaluation boards for MCUs/FPGAs and so on, where large amounts of THT pin headers are used. With regular motherboards, it would be visible with any connector that has THT or mixed THT+SMT pads (like low profile mid mount M.2 slot)