### PR TITLE
Segmented outline drawing mode for GenCAD

### DIFF
--- a/src/openboardview/BRDBoard.cpp
+++ b/src/openboardview/BRDBoard.cpp
@@ -34,9 +34,14 @@ BRDBoard::BRDBoard(const BRDFileBase * const boardFile)
 	{
 		for (auto &brdPoint : m_points) {
 			auto point = make_shared<Point>(brdPoint.x, brdPoint.y);
-			outline_.push_back(point);
+			outline_points_.push_back(point);
 		}
 	}
+
+	outline_segments_.reserve(m_file->outline_segments.size());
+	std::transform(m_file->outline_segments.begin(), m_file->outline_segments.end(), std::back_inserter(outline_segments_), [](const std::pair<BRDPoint, BRDPoint> &s) -> std::pair<Point, Point> {
+		return {{s.first.x, s.first.y}, {s.second.x, s.second.y}};
+	});
 
 	// Populate map of unique nets
 	SharedStringMap<Net> net_map;
@@ -92,7 +97,7 @@ BRDBoard::BRDBoard(const BRDFileBase * const boardFile)
 			} else {
 				comp->board_side = kBoardSideBoth;
 			}
-					 
+
 			comp->mount_type = (brd_part.part_type == BRDPartType::SMD) ? Component::kMountTypeSMD : Component::kMountTypeDIP;
 
 			components_.push_back(comp);
@@ -242,7 +247,11 @@ SharedVector<Net> &BRDBoard::Nets() {
 }
 
 SharedVector<Point> &BRDBoard::OutlinePoints() {
-	return outline_;
+	return outline_points_;
+}
+
+std::vector<std::pair<Point, Point>> &BRDBoard::OutlineSegments() {
+	return outline_segments_;
 }
 
 Board::EBoardType BRDBoard::BoardType() {

--- a/src/openboardview/BRDBoard.h
+++ b/src/openboardview/BRDBoard.h
@@ -21,6 +21,7 @@ class BRDBoard : public Board {
 	SharedVector<Component> &Components();
 	SharedVector<Pin> &Pins();
 	SharedVector<Point> &OutlinePoints();
+	std::vector<std::pair<Point, Point>> &OutlineSegments();
 
   private:
 	static const string kNetUnconnectedPrefix;
@@ -29,5 +30,6 @@ class BRDBoard : public Board {
 	SharedVector<Net> nets_;
 	SharedVector<Component> components_;
 	SharedVector<Pin> pins_;
-	SharedVector<Point> outline_;
+	SharedVector<Point> outline_points_;
+	std::vector<std::pair<Point, Point>> outline_segments_;
 };

--- a/src/openboardview/Board.h
+++ b/src/openboardview/Board.h
@@ -227,10 +227,11 @@ class Board {
 
 	virtual ~Board() {}
 
-	virtual SharedVector<Net> &Nets()             = 0;
-	virtual SharedVector<Component> &Components() = 0;
-	virtual SharedVector<Pin> &Pins()             = 0;
-	virtual SharedVector<Point> &OutlinePoints()  = 0;
+	virtual SharedVector<Net> &Nets()                               = 0;
+	virtual SharedVector<Component> &Components()                   = 0;
+	virtual SharedVector<Pin> &Pins()                               = 0;
+	virtual SharedVector<Point> &OutlinePoints()                    = 0;
+	virtual std::vector<std::pair<Point, Point>> &OutlineSegments() = 0;
 
 	EBoardType BoardType() {
 		return kBoardTypeUnknown;

--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -323,6 +323,8 @@ struct BoardView {
 	void DrawPinTooltips(ImDrawList *draw);
 	void DrawAnnotations(ImDrawList *draw);
 	void DrawOutline(ImDrawList *draw);
+	void DrawOutlinePoints(ImDrawList *draw);
+	void DrawOutlineSegments(ImDrawList *draw);
 	void DrawPins(ImDrawList *draw);
 	void DrawParts(ImDrawList *draw);
 	void DrawBoard();

--- a/src/openboardview/FileFormats/BRDFileBase.h
+++ b/src/openboardview/FileFormats/BRDFileBase.h
@@ -81,6 +81,7 @@ class BRDFileBase {
 	unsigned int num_nails  = 0;
 
 	std::vector<BRDPoint> format;
+	std::vector<std::pair<BRDPoint, BRDPoint>> outline_segments;
 	std::vector<BRDPart> parts;
 	std::vector<BRDPin> pins;
 	std::vector<BRDNail> nails;

--- a/src/openboardview/FileFormats/GenCADFile.h
+++ b/src/openboardview/FileFormats/GenCADFile.h
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 enum ParseVarsCounterEnum {
 #define X(CVAR, NAME) _ignore_me_##CVAR,
@@ -41,7 +42,7 @@ class GenCADFile : public BRDFileBase {
 
 	bool parse_dimension_units(mpc_ast_t *header_ast);
 	bool parse_board_outline(mpc_ast_t *board_ast);
-	void add_arc_to_outline(mpc_ast_t *start, mpc_ast_t *stop, mpc_ast_t *center);
+	std::vector<std::pair<BRDPoint, BRDPoint>> arc_to_segments(mpc_ast_t *start, mpc_ast_t *stop, mpc_ast_t *center);
 	bool parse_vias();
 	bool parse_route_vias(mpc_ast_t *route_ast);
 	bool parse_components();


### PR DESCRIPTION
Should mostly fix outline problems of GenCAD.
Hopefully I didn't break too many things
Breaks at least board fill but really who cares about that.
Also arcs beginning/end do not match exactly with the previous/next line, could be due to float/int conversions.

@swiftgeek @galkinvv 