### PR TITLE
GenCAD: Fix goldfinger parsing

### DIFF
--- a/src/openboardview/FileFormats/BRDFileBase.h
+++ b/src/openboardview/FileFormats/BRDFileBase.h
@@ -36,7 +36,7 @@ struct BRDPoint {
 };
 
 enum class BRDPartMountingSide { Both, Bottom, Top };
-enum class BRDPartType { SMD, ThroughHole };
+enum class BRDPartType { None, SMD, ThroughHole };
 
 struct BRDPart {
 	const char *name = nullptr;
@@ -48,7 +48,7 @@ struct BRDPart {
 	BRDPoint p2{0, 0};
 };
 
-enum class BRDPinSide { Both, Bottom, Top };
+enum class BRDPinSide { None, Both, Bottom, Top };
 
 struct BRDPin {
 	BRDPoint pos;

--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -280,7 +280,7 @@ bool GenCADFile::parse_shape_pins_to_component(
 						pin.net = tmp;
 						nc_counter++;
 					}
-					if (padstack_ast && !is_padstack_smd(padstack_ast)) {
+					if (padstack_ast && is_padstack_drilled(padstack_ast)) {
 						pin.side = BRDPinSide::Both;
 					} else if (part->mounting_side == BRDPartMountingSide::Top) {
 						pin.side = BRDPinSide::Top;
@@ -526,7 +526,7 @@ bool GenCADFile::is_shape_smd(mpc_ast_t *shape_ast) {
 			if (!pad_name) continue;
 
 			mpc_ast_t *padstack_ast = get_padstack_by_name(pad_name);
-			if (padstack_ast && !is_padstack_smd(padstack_ast)) {
+			if (padstack_ast && is_padstack_drilled(padstack_ast)) {
 				return false;
 			}
 			i++;
@@ -590,9 +590,10 @@ char *GenCADFile::get_stringtoend_child(mpc_ast_t *parent, const char *name) {
 	return nullptr;
 }
 
-bool GenCADFile::is_padstack_smd(mpc_ast_t *padstack_ast) {
+bool GenCADFile::is_padstack_drilled(mpc_ast_t *padstack_ast) {
 	mpc_ast_t *drill_size_ast = mpc_ast_get_child(padstack_ast, "drill_size|number|regex");
-	if (drill_size_ast) return atof(drill_size_ast->contents) == 0.0;
+	if (drill_size_ast)
+		return atof(drill_size_ast->contents) != 0.0;
 	return false;
 }
 

--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -287,13 +287,12 @@ bool GenCADFile::parse_shape_pins_to_component(
 						pin.net = tmp;
 						nc_counter++;
 					}
-					if (padstack_ast && is_padstack_drilled(padstack_ast)) {
-						pin.side = BRDPinSide::Both;
-					} else if (part->mounting_side == BRDPartMountingSide::Top) {
+					if (padstack_ast)
+						pin.side = get_padstack_side(padstack_ast, part->mounting_side);
+					else if (part->mounting_side == BRDPartMountingSide::Top)
 						pin.side = BRDPinSide::Top;
-					} else {
+					else
 						pin.side = BRDPinSide::Bottom;
-					}
 					pins.push_back(pin);
 					num_pins++;
 				}

--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -213,7 +213,14 @@ bool GenCADFile::parse_components() {
 						mpc_ast_t *mirror_ast = mpc_ast_get_child(shape_ref_ast, "mirror|string");
 						bool mirror_x         = has_text_content(mirror_ast, "MIRRORX");
 						bool mirror_y         = has_text_content(mirror_ast, "MIRRORY");
-						brd_part.part_type    = is_shape_smd(shape_ast) ? BRDPartType::SMD : BRDPartType::ThroughHole;
+						BRDPartType shape_type = get_shape_type(shape_ast);
+						if (shape_type != BRDPartType::None)
+							brd_part.part_type     = shape_type;
+						else {
+							// BRDPartType::None - Skip as this part does not contain electrical/mechanical pads
+							i++;
+							continue;
+						}
 						parse_shape_pins_to_component(&brd_part, component_rotation_angle, mirror_x, mirror_y, shape_ast);
 						if ( brd_part.part_type == BRDPartType::ThroughHole ) {
 							brd_part.mounting_side = BRDPartMountingSide::Both;
@@ -515,7 +522,7 @@ int GenCADFile::board_unit_to_brd_coordinate(double brdUnit) {
 	return static_cast<int>(brdUnit);
 }
 
-bool GenCADFile::is_shape_smd(mpc_ast_t *shape_ast) {
+BRDPartType GenCADFile::get_shape_type(mpc_ast_t *shape_ast) {
 	for (int i = 0; i >= 0;) {
 		i = mpc_ast_get_index_lb(shape_ast, "shapes_pin|>", i);
 		if (i >= 0) {
@@ -527,12 +534,12 @@ bool GenCADFile::is_shape_smd(mpc_ast_t *shape_ast) {
 
 			mpc_ast_t *padstack_ast = get_padstack_by_name(pad_name);
 			if (padstack_ast && is_padstack_drilled(padstack_ast)) {
-				return false;
+				return BRDPartType::ThroughHole;
 			}
 			i++;
 		}
 	}
-	return true;
+	return BRDPartType::SMD;
 }
 
 char *GenCADFile::get_nonquoted_or_quoted_string_child(mpc_ast_t *parent, const char *name) {

--- a/src/openboardview/FileFormats/GenCADFile.h
+++ b/src/openboardview/FileFormats/GenCADFile.h
@@ -67,7 +67,7 @@ class GenCADFile : public BRDFileBase {
 	bool x_y_ref_to_brd_point(mpc_ast_t *x_y_ref, BRDPoint *point);
 
 	bool is_shape_smd(mpc_ast_t *shape_ast);
-	bool is_padstack_smd(mpc_ast_t *padstack_ast);
+	bool is_padstack_drilled(mpc_ast_t *padstack_ast);
 
 	mpc_ast_t *header_ast     = nullptr;
 	mpc_ast_t *board_ast      = nullptr;

--- a/src/openboardview/FileFormats/GenCADFile.h
+++ b/src/openboardview/FileFormats/GenCADFile.h
@@ -61,6 +61,7 @@ class GenCADFile : public BRDFileBase {
 	mpc_ast_t *get_padstack_by_name(const char *padstack_name);
 	mpc_ast_t *get_pad_by_name(const char *pad_name);
 	double get_padstack_radius(mpc_ast_t *padstack_ast);
+	BRDPinSide get_padstack_side(mpc_ast_t *padstack_ast, BRDPartMountingSide mounting_side);
 	double get_pad_radius(mpc_ast_t *pad_ast);
 
 	int board_unit_to_brd_coordinate(double brdUnit);

--- a/src/openboardview/FileFormats/GenCADFile.h
+++ b/src/openboardview/FileFormats/GenCADFile.h
@@ -66,7 +66,7 @@ class GenCADFile : public BRDFileBase {
 	int board_unit_to_brd_coordinate(double brdUnit);
 	bool x_y_ref_to_brd_point(mpc_ast_t *x_y_ref, BRDPoint *point);
 
-	bool is_shape_smd(mpc_ast_t *shape_ast);
+	BRDPartType get_shape_type(mpc_ast_t *shape_ast);
 	bool is_padstack_drilled(mpc_ast_t *padstack_ast);
 
 	mpc_ast_t *header_ast     = nullptr;


### PR DESCRIPTION
An attempt to fix edge connector parsing (like DIMM/PCIe Card goldfinger), tested with attached test files

~~Also rename `GenCADFile::is_padstack_smd` to `GenCADFile::is_padstack_drilled` to avoid confusion~~ done

~~Most likely, non-copper/drill elements (like silkscreen only) being not omitted (last leftover issue from #247) is related to this change, but somehow padstack would need to be marked as empty (`BRDPinSide::None`) and then component omitted if it doesn't have any copper/drill elements (maybe `is_shape_smd()` would need to change to return part_type directly (so rename to `get_shape_type()`), and return `BRDPartType::None` if it doesn't have any useful elements). `get_shape_type()` could iterate similarly to `get_shape_type()` now, to determine there are no drill/outer copper elements in given shape. Would also make easier any future expansion of `BRDPartType` by via/testpoint or other types~~ implemented

---

[PantherPlus from OCP (Open Compute Project](https://github.com/OpenBoardView/OpenBoardView/files/9431811/PantherPlus.zip)

[Glasgow Debug Tool](https://github.com/OpenBoardView/OpenBoardView/files/9902483/glasgow.zip) - Due to KiCAD limitation, 8 pads from J5 are composed out of several pads each