### PR TITLE
FZFile: parse pad names, enable pad sorting

### DIFF
--- a/src/openboardview/FileFormats/BRDFileBase.h
+++ b/src/openboardview/FileFormats/BRDFileBase.h
@@ -65,10 +65,9 @@ struct BRDPin {
 	const char *snum = nullptr;
 	const char *name = nullptr;
 
-	bool operator<(const BRDPin &p) const // For sorting the vector
-	{
-		return part == p.part ? (std::string(snum) < std::string(p.snum)) : (part < p.part); // sort by part number then pin number
-	}
+	struct LessByPartAndNumberAndName {
+		bool operator()(const BRDPin &a, const BRDPin &b) const;
+	};
 };
 
 struct BRDNail {

--- a/src/openboardview/FileFormats/FZFile.cpp
+++ b/src/openboardview/FileFormats/FZFile.cpp
@@ -133,7 +133,6 @@ char *FZFile::split(char *file_buf, size_t buffer_size, size_t &content_size, ch
 char *FZFile::decompress(char *file_buf, size_t buffer_size, size_t &output_size) {
 	output_size = buffer_size;
 	if (buffer_size == 0) return nullptr;
-
 	char *output = (char *)calloc(output_size, sizeof(char));
 
 	z_stream zst;
@@ -363,7 +362,7 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t fzkey[44]) {
 				char *part = READ_STR();
 				pin.part   = parts_id.at(part);
 				pin.snum   = READ_STR();
-				/*char *name =*/READ_STR();
+				pin.name   = READ_STR();
 				double posx   = READ_DOUBLE();
 				pin.pos.x     = posx * multiplier;
 				double posy   = READ_DOUBLE();
@@ -441,8 +440,8 @@ FZFile::FZFile(std::vector<char> &buf, uint32_t fzkey[44]) {
 			}
 		}
 	}
-
-	//	std::sort(pins.begin(), pins.end()); // sort vector by part num then pin num
+	// sort pins by part num then by num/name
+	std::stable_sort(pins.begin(), pins.end(), BRDPin::LessByPartAndNumberAndName());
 	for (std::vector<int>::size_type i = 0; i < pins.size(); i++) {
 		// update end_of_pins field
 		if (pins[i].part > 0) parts[pins[i].part - 1].end_of_pins = i;


### PR DESCRIPTION
Some .fz files contains pad names,
this change enables their parsing and display.

With this information available the pin sorting is enabled.

If the pin numbers are identical those names are also used for sorting: a special ordering function is implemented to order pins of large BGAs as A0 A1..A9 A10 A11..A99 A100 A101..B0..Z0..AA0..AZ0..BA0..

Unfortunately some .fz files has ICs with very long pin names like VINSEN_AUX_1; such long names makes display cluttered.