### PR TITLE
build: Up required CMake version to allow conditional LTO on Rel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.9)
 # We now use project() VERSION parameter
 if(POLICY CMP0048)
 	cmake_policy(SET CMP0048 NEW)
@@ -6,6 +6,10 @@ endif()
 # Targets with semicolon are imported targets
 if(POLICY CMP0028)
 	cmake_policy(SET CMP0028 NEW)
+endif()
+# LTO
+if(POLICY CMP0069)
+	cmake_policy(SET CMP0069 NEW)
 endif()
 
 # Set OSX target version, before calling project() (inside version.cmake). FORCE is needed when project() is called within an included file

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -179,6 +179,14 @@ elseif(APPLE)
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_ICON_FILE ${PROJECT_NAME_LOWER})
 endif()
 
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT supported OUTPUT error)
+	if (supported)
+		set_property(TARGET ${PROJECT_NAME_LOWER} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+	endif()
+endif()
+
 target_include_directories(${PROJECT_NAME_LOWER} PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}/..


### PR DESCRIPTION
Enables LTO when in Release mode. I've not done any A/B testing, but we save ~250KB on the file size on Windows at least.

CMake version was required to be updated to 3.9 which was release in 2017.