### PR TITLE
GenCAD: Perf fix in get_nonquoted_or_quoted_string_child

### DIFF
--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -542,10 +542,10 @@ bool GenCADFile::is_shape_smd(mpc_ast_t *shape_ast) {
 }
 
 char *GenCADFile::get_nonquoted_or_quoted_string_child(mpc_ast_t *parent, const char *name) {
-	constexpr char *quoted_regex = "|nonquoted_string|regex";
-	constexpr char *add_string   = "|string|>";
+	const char quoted_regex[] = "|nonquoted_string|regex";
+	const char add_string[]   = "|string|>";
 
-	static std::string key(1024, '\0'); // Reserve 1024 so we don't need to call malloc on the backend
+	static std::string key(256, '\0'); // Reserve so we don't need to call malloc on the backend
 	key.assign(name);
 	key.append(quoted_regex);
 
@@ -554,7 +554,6 @@ char *GenCADFile::get_nonquoted_or_quoted_string_child(mpc_ast_t *parent, const 
 		return ret_ast->contents;
 	}
 
-	key.clear();
 	key.assign(name);
 	key.append(add_string);
 

--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -542,17 +542,23 @@ bool GenCADFile::is_shape_smd(mpc_ast_t *shape_ast) {
 }
 
 char *GenCADFile::get_nonquoted_or_quoted_string_child(mpc_ast_t *parent, const char *name) {
-	char *key = static_cast<char *>(malloc(strlen(name) + 25));
-	sprintf(key, "%s|nonquoted_string|regex", name);
-	mpc_ast_t *ret_ast = mpc_ast_get_child(parent, key);
+	constexpr char *quoted_regex = "|nonquoted_string|regex";
+	constexpr char *add_string   = "|string|>";
+
+	static std::string key(1024, '\0'); // Reserve 1024 so we don't need to call malloc on the backend
+	key.assign(name);
+	key.append(quoted_regex);
+
+	mpc_ast_t *ret_ast = mpc_ast_get_child(parent, key.c_str());
 	if (ret_ast) {
-		free(key);
 		return ret_ast->contents;
 	}
 
-	sprintf(key, "%s|string|>", name);
-	ret_ast = mpc_ast_get_child(parent, key);
-	free(key);
+	key.clear();
+	key.assign(name);
+	key.append(add_string);
+
+	ret_ast = mpc_ast_get_child(parent, key.c_str());
 	if (ret_ast) {
 		auto value_ast = mpc_ast_get_child(ret_ast, "regex");
 		if (value_ast) return value_ast->contents;


### PR DESCRIPTION
`sprintf` is incredibly slow, and during profiling with my specific use case this was the hottest function. By using `std::string` in this single function I was able to cut the load time in half.

Before:
![image](https://github.com/user-attachments/assets/16e3f43c-0e11-48bd-8c08-1d5851de54c4)

After:
![image](https://github.com/user-attachments/assets/8d232569-6789-40c0-b032-e05d95ccbb64)

Ideally because this function is only called from *internal* callees' with only 6(?) or so variations we'd just have a switch with `constexpr char*`'s, but this is the most minimally invasive patch.