### PR TITLE
CMake: fix compatibility with CMake 4.x on mingw-w64-ucrt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
-# We now use project() VERSION parameter
-if(POLICY CMP0048)
-	cmake_policy(SET CMP0048 NEW)
-endif()
-# Targets with semicolon are imported targets
-if(POLICY CMP0028)
-	cmake_policy(SET CMP0028 NEW)
-endif()
+cmake_minimum_required(VERSION 3.11)
 
 # Set OSX target version, before calling project() (inside version.cmake). FORCE is needed when project() is called within an included file
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,9 @@ set(GLAD_API "gl=3.2,gles2=2.0" CACHE STRING "GL versions" FORCE) # Build for Op
 set(GLAD_EXTENSIONS "GL_EXT_texture_compression_s3tc,GL_OES_element_index_uint" CACHE STRING "Gl exts" FORCE) # S3TC used to load texture for pins — delete when removing support. The other is used by GLES2.
 set(GLAD_NO_LOADER ON CACHE BOOL "Disable loader" FORCE) # We're using SDL2 loader
 set(GLAD_REPRODUCIBLE ON CACHE BOOL "Reproducible build" FORCE)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.11) # force glad 1.x compatibility with cmake 4.0
 add_subdirectory(glad)
+unset(CMAKE_POLICY_VERSION_MINIMUM)
 
 ## SDL2 ##
 find_package(SDL2 REQUIRED CONFIG)

--- a/src/sqlite3/CMakeLists.txt
+++ b/src/sqlite3/CMakeLists.txt
@@ -1,5 +1,4 @@
 PROJECT(SQlite)
-cmake_minimum_required(VERSION 2.8.12)
 
 add_library(SQLite3 STATIC sqlite3.c)
 target_include_directories(SQLite3 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Support for CMake policies below 3.10 is deprecated since CMake 3.31 https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html#policy-version

The oldest platform targeted by OpenBoardView is RHEL8-like distros, having CMake 3.11.

So switch to requitring CMake 3.11 - this automatically switches all older policies to NEW behaviour, so explicit policy seting is removed

Explicit declaration of needed version for subfolders is removed

Note: zlib submodule is not updated for CMake4 support,
so platforms having CMake4 are expected to provide system zlib.