### PR TITLE
Fix non-operational File->Open with macOS Sequoia.

### DIFF
--- a/asset/Info.plist
+++ b/asset/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>openboardview</string>
+	<key>CFBundleGetInfoString</key>
+	<string>OpenBoardview</string>
+	<key>CFBundleIconFile</key>
+	<string>openboardview</string>
+	<key>CFBundleIdentifier</key>
+	<string>OpenBoardview</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string></string>
+	<key>CFBundleName</key>
+	<string>OpenBoardview</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>MIT Licence</string>
+</dict>
+</plist>

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -148,6 +148,7 @@ endif()
 # Must be defined in the same directory as the add_executable including the file
 set_source_files_properties(${ASSETS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
+
 set(GENCAD_FILE_GRAMMAR_GENERATOR
 	"${CMAKE_CURRENT_SOURCE_DIR}/../../utilities/generate_grammar_header.py")
 
@@ -177,6 +178,10 @@ if(MINGW) # Dirty fix to force linking all libs (esp. libstdc++) statically for 
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES LINK_SEARCH_END_STATIC 1)
 elseif(APPLE)
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_ICON_FILE ${PROJECT_NAME_LOWER})
+	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES
+          MACOSX_BUNDLE TRUE
+          MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/../../asset/Info.plist
+	)   
 endif()
 
 target_include_directories(${PROJECT_NAME_LOWER} PRIVATE


### PR DESCRIPTION
Due to the new security model, Sequoia now fails to launch the File-Open window because an inDomain value is null/nil.

Cause seems to be due to CMake using its own internal Info.plist generator which doesn't appear to work right for the new requirements.

Dedicated  Info.plist added in to asset folder. 

*** Consider this as a placeholder for people wanting to resolve the issue.  I will experiement to see if modifying the Info.plist parameters within CMake itself will resolve the issue

( try these options set within the CMakeList.txt instead of this PR fix )
https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE_INFO_PLIST.html

![Screenshot at 2025-04-28 11-42-42](https://github.com/user-attachments/assets/0e5a4b03-ea46-4193-8132-041fe79579de)
