### PR TITLE
Fix for non working FileOpen on macOS Sequoia

### DIFF
--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -180,7 +180,6 @@ elseif(APPLE)
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_NAME ${PROJECT_NAME_LOWER})
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_INFO_STRING "Boardview viewing")
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_GUI_IDENTIFIER "org.openboardview.openboardview")
-#	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_${PROJECT_NAME_LOWER})
 endif()
 
 target_include_directories(${PROJECT_NAME_LOWER} PRIVATE

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -177,6 +177,10 @@ if(MINGW) # Dirty fix to force linking all libs (esp. libstdc++) statically for 
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES LINK_SEARCH_END_STATIC 1)
 elseif(APPLE)
 	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_ICON_FILE ${PROJECT_NAME_LOWER})
+	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_NAME ${PROJECT_NAME_LOWER})
+	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_INFO_STRING "Boardview viewing")
+	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_GUI_IDENTIFIER "org.openboardview.openboardview")
+#	set_target_properties(${PROJECT_NAME_LOWER} PROPERTIES MACOSX_BUNDLE_${PROJECT_NAME_LOWER})
 endif()
 
 target_include_directories(${PROJECT_NAME_LOWER} PRIVATE


### PR DESCRIPTION
Add missing PLIST Bundle parameter that is required for File->Open to work on Sequoia.