### PR TITLE
Remove the x86_64 from the OSX make flag if arm64 is found

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ if [ $THREADS -eq 1 ]; then
 fi
 
 if [ "$(uname -m)" = "arm64" ]; then
-  COMPILEFLAGS="$COMPILEFLAGS -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+  COMPILEFLAGS="$COMPILEFLAGS -DCMAKE_OSX_ARCHITECTURES=arm64"
 fi
 
 # Now compile the source code and install it in server's directory


### PR DESCRIPTION
If the flag is kept the build script fails with linking errors!

[100%] Linking CXX executable openboardview.app/Contents/MacOS/openboardview
ld: warning: ignoring file '/opt/homebrew/Cellar/sdl2/2.32.10/lib/libSDL2.dylib': found architecture 'arm64', required architecture 'x86_64'
ld: warning: ignoring file '/opt/homebrew/Cellar/sdl2/2.32.10/lib/libSDL2main.a(SDL_dummy_main.o)': found architecture 'arm64', required architecture 'x86_64'
Undefined symbols for architecture x86_64:
  "_SDL_CaptureMouse", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_CreateSystemCursor", referenced from:
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ...
  "_SDL_CreateWindow", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_DestroyWindow", referenced from:
      cleanupAndExit(int) in main_opengl.cpp.o
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
  "_SDL_EnableScreenSaver", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_EventState", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_FreeCursor", referenced from:
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ...
  "_SDL_GL_CreateContext", referenced from:
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
  "_SDL_GL_DeleteContext", referenced from:
      ImGuiRendererSDL::~ImGuiRendererSDL() in ImGuiRendererSDL.cpp.o
  "_SDL_GL_GetDrawableSize", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GL_GetProcAddress", referenced from:
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
  "_SDL_GL_GetSwapInterval", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_GL_LoadLibrary", referenced from:
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
  "_SDL_GL_MakeCurrent", referenced from:
      ImGuiRendererSDL::renderFrame(ImVec4 const&) in ImGuiRendererSDL.cpp.o
  "_SDL_GL_ResetAttributes", referenced from:
      ImGuiRendererSDL::setGLVersion() in ImGuiRendererSDL.cpp.o
  "_SDL_GL_SetAttribute", referenced from:
      ImGuiRendererSDL::ImGuiRendererSDL(SDL_Window*) in ImGuiRendererSDL.cpp.o
      ImGuiRendererSDL::ImGuiRendererSDL(SDL_Window*) in ImGuiRendererSDL.cpp.o
      ImGuiRendererSDL::ImGuiRendererSDL(SDL_Window*) in ImGuiRendererSDL.cpp.o
      ImGuiRendererSDLGL1::setGLVersion() in ImGuiRendererSDLGL1.cpp.o
      ImGuiRendererSDLGL1::setGLVersion() in ImGuiRendererSDLGL1.cpp.o
      ImGuiRendererSDLGL3::setGLVersion() in ImGuiRendererSDLGL3.cpp.o
      ImGuiRendererSDLGL3::setGLVersion() in ImGuiRendererSDLGL3.cpp.o
      ImGuiRendererSDLGL3::setGLVersion() in ImGuiRendererSDLGL3.cpp.o
      ImGuiRendererSDLGL3::setGLVersion() in ImGuiRendererSDLGL3.cpp.o
      ...
  "_SDL_GL_SetSwapInterval", referenced from:
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
  "_SDL_GL_SwapWindow", referenced from:
      ImGuiRendererSDL::renderFrame(ImVec4 const&) in ImGuiRendererSDL.cpp.o
  "_SDL_GL_UnloadLibrary", referenced from:
      ImGuiRendererSDL::~ImGuiRendererSDL() in ImGuiRendererSDL.cpp.o
  "_SDL_GameControllerClose", referenced from:
      ImGui_ImplSDL2_CloseGamepads() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GameControllerGetAxis", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ...
  "_SDL_GameControllerGetButton", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ...
  "_SDL_GameControllerOpen", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetClipboardText", referenced from:
      ImGui_ImplSDL2_GetClipboardText(ImGuiContext*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetCurrentVideoDriver", referenced from:
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetDisplayUsableBounds", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_GetError", referenced from:
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
  "_SDL_GetGlobalMouseState", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetKeyboardFocus", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetPerformanceCounter", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetPerformanceFrequency", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetRelativeMouseMode", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetRendererOutputSize", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetVersion", referenced from:
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetWindowDisplayIndex", referenced from:
      ImGui_ImplSDL2_GetContentScaleForWindow(SDL_Window*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetWindowFlags", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetWindowID", referenced from:
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetWindowPosition", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetWindowSize", referenced from:
      _main in main_opengl.cpp.o
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_GetWindowWMInfo", referenced from:
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_Init", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_IsGameController", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_LogDebug", referenced from:
      BackgroundImage::loadFromConfig(ghc::filesystem::path const&) in BackgroundImage.cpp.o
      PDFFile::loadFromConfig(ghc::filesystem::path const&) in PDFFile.cpp.o
  "_SDL_LogError", referenced from:
      file_as_buffer(ghc::filesystem::path const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) in utils.cpp.o
      file_as_buffer(ghc::filesystem::path const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) in utils.cpp.o
      file_as_buffer(ghc::filesystem::path const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) in utils.cpp.o
      file_as_buffer(ghc::filesystem::path const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) in utils.cpp.o
      lookup_file_insensitive(ghc::filesystem::path const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) in utils.cpp.o
      ADFile::ADFile(std::__1::vector<char, std::__1::allocator<char>>&) in ADFile.cpp.o
      ADFile::ADFile(std::__1::vector<char, std::__1::allocator<char>>&) in ADFile.cpp.o
      ADFile::ADFile(std::__1::vector<char, std::__1::allocator<char>>&) in ADFile.cpp.o
      ...
  "_SDL_LogInfo", referenced from:
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
      BackgroundImage::loadFromConfig(ghc::filesystem::path const&) in BackgroundImage.cpp.o
      Fonts::load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) in Fonts.cpp.o
      PDFFile::loadFromConfig(ghc::filesystem::path const&) in PDFFile.cpp.o
      parse_parameters(int, char**, globals*) in main_opengl.cpp.o
  "_SDL_LogSetAllPriority", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_LogWarn", referenced from:
      GenCADFile::parse_file(std::__1::vector<char, std::__1::allocator<char>> const&) in GenCADFile.cpp.o
      GenCADFile::parse_file(std::__1::vector<char, std::__1::allocator<char>> const&) in GenCADFile.cpp.o
      XZZPCBFile::process_blocks(std::__1::vector<char, std::__1::allocator<char>> const&, unsigned int, unsigned int) in XZZPCBFile.cpp.o
      XZZPCBFile::process_block(std::__1::vector<char, std::__1::allocator<char>>&, unsigned char) in XZZPCBFile.cpp.o
      XZZPCBFile::parse_part_block(std::__1::vector<char, std::__1::allocator<char>>&) in XZZPCBFile.cpp.o
      ImGuiRendererSDL::init() in ImGuiRendererSDL.cpp.o
      Fonts::load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) in Fonts.cpp.o
      Fonts::load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) in Fonts.cpp.o
      ...
  "_SDL_NumJoysticks", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_OpenURL", referenced from:
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*)::$_0::__invoke(ImGuiContext*, char const*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_PollEvent", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_PushEvent", referenced from:
      _main in main_opengl.cpp.o
      openFile(objc_object*, objc_selector*) in osx.mm.o
  "_SDL_Quit", referenced from:
      cleanupAndExit(int) in main_opengl.cpp.o
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
  "_SDL_SetClipboardText", referenced from:
      ImGui_ImplSDL2_SetClipboardText(ImGuiContext*, char const*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_SetCursor", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_SetHint", referenced from:
      _main in main_opengl.cpp.o
      _main in main_opengl.cpp.o
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_Init(SDL_Window*, SDL_Renderer*, void*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_SetTextInputRect", referenced from:
      ImGui_ImplSDL2_PlatformSetImeData(ImGuiContext*, ImGuiViewport*, ImGuiPlatformImeData*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_SetWindowTitle", referenced from:
      _main in main_opengl.cpp.o
  "_SDL_ShowCursor", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_Vulkan_GetDrawableSize", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_WarpMouseInWindow", referenced from:
      ImGui_ImplSDL2_NewFrame() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_free", referenced from:
      ImGui_ImplSDL2_Shutdown() in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
      ImGui_ImplSDL2_GetClipboardText(ImGuiContext*) in libimgui.a[x86_64][7](imgui_impl_sdl2.cpp.o)
  "_SDL_strdup", referenced from:
      openFile(objc_object*, objc_selector*) in osx.mm.o
ld: symbol(s) not found for architecture x86_64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/openboardview/openboardview.app/Contents/MacOS/openboardview] Error 1
make[1]: *** [src/openboardview/CMakeFiles/openboardview.dir/all] Error 2
make: *** [all] Error 2
MAKE INSTALL/STRIP FAILED