### PR TITLE
ci: older macos-intel github runner closed, switch to new one

### DIFF
--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -93,7 +93,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: MacOS dependencies
-        run: brew update && brew install sdl2
+        run: |
+          brew tap-new local/oldermacos
+          ln -s $(pwd)/utilities/brew_oldermacos/sdl2.rb "$(brew --repository local/oldermacos)/Formula/sdl2.rb"
+          brew install local/oldermacos/sdl2
       - name: MacOS build
         run: TERM=xterm bash ./build.sh --recompile
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/make_packages.yml
+++ b/.github/workflows/make_packages.yml
@@ -86,7 +86,7 @@ jobs:
           name: "openboardview-32bit.exe.${{ github.sha }}"
           path: bin/openboardview.exe
   build-and-package_intel-DMG:
-    runs-on: macos-13 # intel runner
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,7 +98,7 @@ jobs:
         run: TERM=xterm bash ./build.sh --recompile
       - uses: actions/upload-artifact@v4
         with:
-          name: "openboardview_unsigned_macos13_intel_dmg.${{ github.sha }}"
+          name: "openboardview_unsigned_macos_intel_dmg.${{ github.sha }}"
           path: '*.dmg'
   build-and-package_universal-DMG:
     runs-on: macos-15

--- a/utilities/brew_oldermacos/sdl2.rb
+++ b/utilities/brew_oldermacos/sdl2.rb
@@ -1,0 +1,33 @@
+# Based on upstream sdl2 furmulae from https://github.com/Homebrew/homebrew-core/raw/refs/tags/26-tahoe/Formula/s/sdl2.rb
+# With addition of MACOSX_DEPLOYMENT_TARGET (same value in CMakeLists) to tell linker not produce DyldChainedFixups=0x80000034 unsupported by MacOS<10.15
+# All unused features cleaned up for simplicity
+
+class Sdl2 < Formula
+  desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
+  homepage "https://www.libsdl.org/"
+  url "https://github.com/libsdl-org/SDL/releases/download/release-2.32.10/SDL2-2.32.10.tar.gz"
+  sha256 "5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165"
+  license "Zlib"
+
+
+  def install
+    # We have to do this because most build scripts assume that all SDL modules
+    # are installed to the same prefix. Consequently SDL stuff cannot be
+    # keg-only but I doubt that will be needed.
+    inreplace "sdl2.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
+
+    args = %W[--prefix=#{prefix} --enable-hidapi]
+    args += if OS.mac?
+      %w[--without-x]
+    end
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system bin/"sdl2-config", "--version"
+  end
+end

--- a/utilities/brew_oldermacos/sdl2.rb
+++ b/utilities/brew_oldermacos/sdl2.rb
@@ -19,9 +19,11 @@ class Sdl2 < Formula
     system "./autogen.sh" if build.head?
 
     args = %W[--prefix=#{prefix} --enable-hidapi]
-    args += if OS.mac?
-      %w[--without-x]
+    if OS.mac?
+        args += %w[--without-x]
     end
+    # pass -march=x86-64 to make the binary compatible with any x86_64 MAC hardware, including the first Merom-based
+    ENV["HOMEBREW_ARCHFLAGS"]="-march=x86-64"
     ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
resulting binary was NOT checked in any way, just the build success