### PR TITLE
Fix infinite loop caused by negative board surface size

### DIFF
--- a/src/openboardview/main_opengl.cpp
+++ b/src/openboardview/main_opengl.cpp
@@ -352,6 +352,10 @@ int main(int argc, char **argv) {
 	app.m_board_surface.x = g.width;
 	app.m_board_surface.y = g.height;
 	if (app.config.showInfoPanel) app.m_board_surface.x -= app.m_info_surface.x;
+	if (app.m_board_surface.x <= 0.0f) {
+		app.m_board_surface.x = g.width * 0.66f;
+		app.m_info_surface.x = g.width - app.m_board_surface.x;
+	}
 
 	if (g.font_size > 0.0) app.config.fontSize = g.font_size;
 


### PR DESCRIPTION
After the change in e238d63, having `windowX=1200`, `dpi=200`, and `infoPanelWidth = 652` in `obv.conf` on Linux would cause `app.m_board_surface.x` to be negative, which caused `sx` to be negative, which caused `m_scale` to be negative, which caused `vdelta` to be negative, which caused `y` to never reach `yend`, causing an infinite loop. Fix this by detecting the negative condition early and setting `app.m_board_surface.x` and `app.m_info_surface.x` to reasonable values.

Fixes #348.

Fixes: e238d63 ("High-DPI support on Windows")