### PR TITLE
FileFormats/{CAEFile,FZFile}: Correct component side placement

### DIFF
--- a/src/openboardview/FileFormats/FZFile.cpp
+++ b/src/openboardview/FileFormats/FZFile.cpp
@@ -359,9 +359,9 @@ void FZFile::parse(std::vector<char> &buf, const std::array<uint32_t, 44> &fzkey
 				/*char *srotate =*/READ_STR();
 				part.part_type = BRDPartType::SMD;
 				if (!strcmp(smirror, "YES"))
-					part.mounting_side = BRDPartMountingSide::Top; // SMD part on top
-				else
 					part.mounting_side = BRDPartMountingSide::Bottom; // SMD part on bottom
+				else
+					part.mounting_side = BRDPartMountingSide::Top; // SMD part on top
 				part.end_of_pins       = 0;
 				parts.push_back(part);
 				parts_id[part.name] = parts.size();


### PR DESCRIPTION
When a component in an FZ or CAE file is mirrored, that means it's on the bottom of the board, not the top. Before this change, a board would have to be rotated 180 degrees, flipped, and then mirrored to be displayed in the correct orientation. After this change, FZ and CAE files are displayed correctly the moment they're opened, without requiring any user input.

Fixes #350