### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/sqlite3/sqlite3.c
+++ b/src/sqlite3/sqlite3.c
@@ -117951,6 +117951,7 @@ SQLITE_PRIVATE int sqlite3Select(
   */
   if( (p->selFlags & (SF_Distinct|SF_Aggregate))==SF_Distinct 
    && sqlite3ExprListCompare(sSort.pOrderBy, pEList, -1)==0
+   && p->pWin==0
   ){
     p->selFlags &= ~SF_Distinct;
     pGroupBy = p->pGroupBy = sqlite3ExprListDup(db, pEList, 0);


### PR DESCRIPTION
Hi again,

Our tool identified another potential vulnerability in a clone function `sqlite3Select()` in `src/sqlite3/sqlite3.c` sourced from [sqlite/sqlite](https://github.com/sqlite/sqlite). These issues, originally reported in [CVE-2019-19244](https://nvd.nist.gov/vuln/detail/CVE-2019-19244), were resolved in the repository via this commit https://github.com/sqlite/sqlite/commit/e59c562b3f6894f84c715772c4b116d7b5c01348.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.