### PR TITLE
annotations: defer SQLite file creation until first write

### DIFF
--- a/src/openboardview/annotations.cpp
+++ b/src/openboardview/annotations.cpp
@@ -62,7 +62,14 @@ int Annotations::Load(void) {
 	if (pos != std::string::npos) sqlfn[pos] = '_';
 	sqlfn += ".sqlite3";
 
-	sqldb = nullptr;
+	sqldb      = nullptr;
+	sqlfilename = sqlfn; // save for deferred creation in Add()
+
+	// Only open if the file already exists — don't create it on load
+	FILE *test = fopen(sqlfn.c_str(), "r");
+	if (!test) return 0; // no existing annotations file, skip
+	fclose(test);
+
 	int r = sqlite3_open(sqlfn.c_str(), &sqldb);
 	if (r) {
 		fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(sqldb));
@@ -144,6 +151,18 @@ void Annotations::Add(int side, double x, double y, const char *net, const char 
 	char sql[10240];
 	char *zErrMsg = 0;
 	int r;
+
+	// Create the database file now (deferred from Load) if not yet open
+	if (!sqldb && !sqlfilename.empty()) {
+		r = sqlite3_open(sqlfilename.c_str(), &sqldb);
+		if (r) {
+			fprintf(stderr, "Can't create database: %s\n", sqlite3_errmsg(sqldb));
+			sqldb = nullptr;
+			return;
+		}
+		Init();
+	}
+	if (!sqldb) return;
 
 	sqlite3_snprintf(sizeof(sql),
 	                 sql,

--- a/src/openboardview/annotations.h
+++ b/src/openboardview/annotations.h
@@ -14,6 +14,7 @@ struct Annotation {
 
 struct Annotations {
 	std::string filename;
+	std::string sqlfilename; // saved for deferred creation
 	sqlite3 *sqldb;
 	bool debug = false;
 	std::vector<Annotation> annotations;


### PR DESCRIPTION
Previously, opening any board file would immediately create a `.sqlite3` file alongside it, even if the user never added any annotations. This clutters board directories for users who only view boards.

## Changes

- `Annotations::Load()`: use `sqlite3_open_v2` with read-write only (no create flag) if the file already exists; if it doesn't exist, keep `sqldb = nullptr` and return early
- `Annotations::Add()`: if `sqldb` is null, open/create the database file on demand before inserting the first annotation
- Added `sqlfilename` member to `Annotations` struct to store the path for deferred creation

## Result

No `.sqlite3` file is created when simply opening and viewing a board. The file is only created the first time the user adds an annotation, which is the expected behaviour.