### PR TITLE
macOS: add Skim PDF bridge (PDFBridgeSkim)

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -158,7 +158,7 @@ int BoardView::LoadFile(const filesystem::path &filepath) {
 				auto conffilepath = filepath;
 				conffilepath.replace_extension("conf");
 				backgroundImage.loadFromConfig(conffilepath);
-				pdfFile.loadFromConfig(conffilepath);
+				pdfFile.loadFromConfig(conffilepath, filesystem::u8path(config.pdfDirectory));
 
 				pdfBridge.OpenDocument(pdfFile);
 

--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -19,6 +19,7 @@
 #include "GUI/Preferences/BoardSettings/BoardSettings.h"
 #include "PDFBridge/PDFBridge.h"
 #include "PDFBridge/PDFBridgeEvince.h"
+#include "PDFBridge/PDFBridgeSkim.h"
 #include "PDFBridge/PDFBridgeSumatra.h"
 #include "PDFBridge/PDFFile.h"
 #include <cstdint>
@@ -64,6 +65,8 @@ struct BoardView {
 	PDFBridgeEvince pdfBridge;
 #elif defined(_WIN32)
 	PDFBridgeSumatra &pdfBridge = PDFBridgeSumatra::GetInstance(obvconfig);
+#elif defined(__APPLE__)
+	PDFBridgeSkim pdfBridge;
 #else
 	PDFBridge pdfBridge; // Dummy implementation
 #endif

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -139,7 +139,9 @@ else()
 if(APPLE)
 	set(SOURCES ${SOURCES}
 		osx.mm
+		PDFBridge/PDFBridgeSkim.mm
 	)
+	set_source_files_properties(PDFBridge/PDFBridgeSkim.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
 endif()
 	set(SOURCES ${SOURCES}
 		unix.cpp

--- a/src/openboardview/GUI/Config.cpp
+++ b/src/openboardview/GUI/Config.cpp
@@ -131,6 +131,9 @@ void Config::readFromConfig(Confparse &obvconfig) {
 	pdfSoftwarePath = obvconfig.ParseStr("pdfSoftwarePath", "SumatraPDF.exe");
 #endif
 
+	pdfDirectory = obvconfig.ParseStr("pdfDirectory", "");
+	brdDirectory = obvconfig.ParseStr("brdDirectory", "");
+
 	/*
 	 * Some machines (Atom etc) don't have enough CPU/GPU
 	 * grunt to cope with the large number of AA'd circles
@@ -212,6 +215,9 @@ void Config::writeToConfig(Confparse &obvconfig) {
 #ifdef _WIN32
 	obvconfig.WriteStr("pdfSoftwarePath", pdfSoftwarePath.c_str());
 #endif
+
+	obvconfig.WriteStr("pdfDirectory", pdfDirectory.c_str());
+	obvconfig.WriteStr("brdDirectory", brdDirectory.c_str());
 
 	obvconfig.WriteBool("slowCPU", slowCPU);
 

--- a/src/openboardview/GUI/Config.h
+++ b/src/openboardview/GUI/Config.h
@@ -57,6 +57,9 @@ public:
 	std::string pdfSoftwarePath = "";
 #endif
 
+	std::string pdfDirectory = "";
+	std::string brdDirectory = "";
+
 	template<size_t N>
 	std::array<uint32_t, N> DecodeKey(const char *keytext);
 

--- a/src/openboardview/GUI/Preferences/Program.cpp
+++ b/src/openboardview/GUI/Preferences/Program.cpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "platform.h"
+
 #include "Program.h"
 
 #include "imgui/imgui.h"
@@ -83,9 +85,39 @@ void Program::render() {
 			}
 		}
 
-#ifdef _WIN32
 		ImGui::Separator();
 
+		RightAlignedText("PDF folder", DPI(250));
+		ImGui::SameLine();
+		{
+			std::vector<char> buf(config.pdfDirectory.c_str(), config.pdfDirectory.c_str() + config.pdfDirectory.size() + 1);
+			buf.resize(32768, '\0');
+			if (ImGui::InputText("##pdfDirectory", buf.data(), buf.size()))
+				config.pdfDirectory = buf.data();
+			ImGui::SameLine();
+			if (ImGui::Button("Browse##pdfDirectory")) {
+				auto path = show_folder_picker();
+				if (!path.empty()) config.pdfDirectory = path.string();
+			}
+		}
+
+		RightAlignedText("BRD folder", DPI(250));
+		ImGui::SameLine();
+		{
+			std::vector<char> buf(config.brdDirectory.c_str(), config.brdDirectory.c_str() + config.brdDirectory.size() + 1);
+			buf.resize(32768, '\0');
+			if (ImGui::InputText("##brdDirectory", buf.data(), buf.size()))
+				config.brdDirectory = buf.data();
+			ImGui::SameLine();
+			if (ImGui::Button("Browse##brdDirectory")) {
+				auto path = show_folder_picker();
+				if (!path.empty()) config.brdDirectory = path.string();
+			}
+		}
+
+		ImGui::Separator();
+
+#ifdef _WIN32
 		RightAlignedText("PDF software executable", DPI(250));
 		ImGui::SameLine();
 

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.h
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.h
@@ -1,0 +1,40 @@
+#ifndef _PDFBRIDGESKIM_H_
+#define _PDFBRIDGESKIM_H_
+
+#ifdef __APPLE__
+
+#include "PDFBridge.h"
+#include "PDFFile.h"
+
+#include <string>
+#include <atomic>
+#include <chrono>
+
+class PDFBridgeSkim : public PDFBridge {
+private:
+	std::string currentPdfPath;
+	std::string selection;
+	std::string lastPolledSelection;
+	std::string lastSearchTerm;
+	int lastFoundPage{0};
+	std::atomic<bool> hasNewSelection{false};
+	std::chrono::steady_clock::time_point lastPollTime{};
+
+	static std::string escapeForAppleScript(const std::string &s);
+	static void runScript(const std::string &script);
+	static std::string runScriptResult(const std::string &script);
+
+public:
+	PDFBridgeSkim();
+	~PDFBridgeSkim();
+
+	void OpenDocument(const PDFFile &pdfFile) override;
+	void CloseDocument() override;
+	void DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive) override;
+	bool HasNewSelection() override;
+	std::string GetSelection() const override;
+};
+
+#endif // __APPLE__
+
+#endif // _PDFBRIDGESKIM_H_

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.mm
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.mm
@@ -1,0 +1,161 @@
+#include "PDFBridgeSkim.h"
+
+#ifdef __APPLE__
+
+#import <Foundation/Foundation.h>
+#include <SDL.h>
+
+PDFBridgeSkim::PDFBridgeSkim() {}
+PDFBridgeSkim::~PDFBridgeSkim() {}
+
+std::string PDFBridgeSkim::escapeForAppleScript(const std::string &s) {
+	std::string result;
+	for (char c : s) {
+		if (c == '"') result += "\\\"";
+		else result += c;
+	}
+	return result;
+}
+
+void PDFBridgeSkim::runScript(const std::string &script) {
+	// Write script to temp file and run with osascript
+	std::string tmpFile = "/tmp/obv_skim_script.applescript";
+	FILE *f = fopen(tmpFile.c_str(), "w");
+	if (!f) return;
+	fwrite(script.c_str(), 1, script.size(), f);
+	fclose(f);
+	std::string cmd = "osascript " + tmpFile + " &>/dev/null &";
+	system(cmd.c_str());
+}
+
+std::string PDFBridgeSkim::runScriptResult(const std::string &script) {
+	std::string tmpFile = "/tmp/obv_skim_query.applescript";
+	FILE *f = fopen(tmpFile.c_str(), "w");
+	if (!f) return "";
+	fwrite(script.c_str(), 1, script.size(), f);
+	fclose(f);
+	std::string cmd = "osascript " + tmpFile + " 2>/dev/null";
+	FILE *pipe = popen(cmd.c_str(), "r");
+	if (!pipe) return "";
+	char buf[512];
+	std::string result;
+	while (fgets(buf, sizeof(buf), pipe)) result += buf;
+	pclose(pipe);
+	if (!result.empty() && result.back() == '\n') result.pop_back();
+	return result;
+}
+
+void PDFBridgeSkim::OpenDocument(const PDFFile &pdfFile) {
+	auto pdfPath = pdfFile.getPath();
+	if (!filesystem::exists(pdfPath)) {
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: PDF file does not exist: %s",
+			pdfPath.generic_string().c_str());
+		return;
+	}
+
+	currentPdfPath = filesystem::canonical(pdfPath).string();
+	std::string escaped = escapeForAppleScript(currentPdfPath);
+
+	std::string script =
+		"tell application \"Skim\"\n"
+		"    activate\n"
+		"    open POSIX file \"" + escaped + "\"\n"
+		"end tell";
+
+	runScript(script);
+	SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim: opened %s", currentPdfPath.c_str());
+}
+
+void PDFBridgeSkim::CloseDocument() {
+	currentPdfPath = "";
+}
+
+void PDFBridgeSkim::DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive) {
+	if (currentPdfPath.empty()) {
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: no document open");
+		return;
+	}
+
+	std::string escaped = escapeForAppleScript(str);
+
+	std::string docName = filesystem::path(currentPdfPath).filename().string();
+	std::string escapedDoc = escapeForAppleScript(docName);
+	std::string caseSens = caseSensitive ? " case sensitive search yes" : "";
+
+	bool sameTerm = (str == lastSearchTerm);
+	lastSearchTerm = str;
+
+	// Aynı terme tekrar basılınca son bulunan sayfadan sonrasından ara
+	// Farklı terme basılınca baştan başla
+	std::string fromClause;
+	if (sameTerm && lastFoundPage > 0) {
+		fromClause = " from character 1 of page " + std::to_string(lastFoundPage + 1) + " of doc";
+	} else {
+		fromClause = " from character 1 of page 1 of doc";
+		lastFoundPage = 0;
+	}
+
+	std::string script =
+		"tell application \"Skim\"\n"
+		"    activate\n"
+		"    set doc to document \"" + escapedDoc + "\"\n"
+		"    set r to find doc text \"" + escaped + "\"" + fromClause + caseSens + "\n"
+		"    if (count of r) > 0 then\n"
+		"        set selection of doc to r\n"
+		"        go doc to item 1 of r\n"
+		"        return index of current page of doc\n"
+		"    else\n"
+		"        return 0\n"
+		"    end if\n"
+		"end tell";
+
+	std::string result = runScriptResult(script);
+	if (!result.empty() && result != "0") {
+		try { lastFoundPage = std::stoi(result); } catch (...) {}
+	} else if (result == "0" && sameTerm && lastFoundPage > 0) {
+		// Sona gelindi, başa dön
+		lastFoundPage = 0;
+		DocumentSearch(str, wholeWordsOnly, caseSensitive);
+		return;
+	}
+	SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim: searching for '%s' page=%s", str.c_str(), result.c_str());
+}
+
+bool PDFBridgeSkim::HasNewSelection() {
+	if (currentPdfPath.empty()) return false;
+
+	// Poll at most every 2 seconds to avoid freezing the UI
+	auto now = std::chrono::steady_clock::now();
+	if (std::chrono::duration_cast<std::chrono::seconds>(now - lastPollTime).count() < 2)
+		return false;
+	lastPollTime = now;
+
+	// Poll Skim's current text selection for reverse search
+	std::string script =
+		"tell application \"Skim\"\n"
+		"    if (count of documents) > 0 then\n"
+		"        set sel to selection of front document\n"
+		"        if sel is not missing value then\n"
+		"            return string of sel\n"
+		"        end if\n"
+		"    end if\n"
+		"    return \"\"\n"
+		"end tell";
+
+	std::string polled = runScriptResult(script);
+
+	if (!polled.empty() && polled != lastPolledSelection) {
+		lastPolledSelection = polled;
+		selection = polled;
+		hasNewSelection = true;
+		return true;
+	}
+
+	return false;
+}
+
+std::string PDFBridgeSkim::GetSelection() const {
+	return selection;
+}
+
+#endif // __APPLE__

--- a/src/openboardview/PDFBridge/PDFFile.cpp
+++ b/src/openboardview/PDFBridge/PDFFile.cpp
@@ -24,15 +24,21 @@ void PDFFile::close() {
 	this->pdfBridge->CloseDocument();
 }
 
-void PDFFile::loadFromConfig(const filesystem::path &filepath) {
+void PDFFile::loadFromConfig(const filesystem::path &filepath, const filesystem::path &pdfSearchDir) {
 	configFilepath = filepath; // save filepath for latter use with writeToConfig
 
 	// Use boardview file path as default PDF file path, with ext replaced with .pdf
 	path = filepath;
 	path.replace_extension("pdf");
 
-	if (!filesystem::exists(filepath)) { // Config file doesn't exist, do not attempt to read or write it and load images
+	if (!filesystem::exists(filepath)) { // Config file doesn't exist
 		SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Board configuration file %s does not exist", filepath.generic_string().c_str());
+		// pdfSearchDir varsa yine de kontrol et
+		if (!pdfSearchDir.empty()) {
+			auto candidate = pdfSearchDir / path.filename();
+			if (filesystem::exists(candidate))
+				path = candidate;
+		}
 		return;
 	}
 
@@ -47,6 +53,13 @@ void PDFFile::loadFromConfig(const filesystem::path &filepath) {
 	std::string pdfFilePathStr{confparse.ParseStr("PDFFilePath", "")};
 	if (!pdfFilePathStr.empty())
 		path = configDir/filesystem::u8path(pdfFilePathStr);
+
+	// Eğer PDF bulunamadıysa ve pdfSearchDir tanımlıysa orada ara
+	if (!filesystem::exists(path) && !pdfSearchDir.empty()) {
+		auto candidate = pdfSearchDir / path.filename();
+		if (filesystem::exists(candidate))
+			path = candidate;
+	}
 
 	writeToConfig(filepath);
 }

--- a/src/openboardview/PDFBridge/PDFFile.h
+++ b/src/openboardview/PDFBridge/PDFFile.h
@@ -33,7 +33,7 @@ public:
 	void reload();
 	void close();
 
-	void loadFromConfig(const filesystem::path &filepath);
+	void loadFromConfig(const filesystem::path &filepath, const filesystem::path &pdfSearchDir = {});
 	void writeToConfig(const filesystem::path &filepath);
 	filesystem::path getPath() const;
 

--- a/src/openboardview/osx.mm
+++ b/src/openboardview/osx.mm
@@ -18,6 +18,21 @@ const filesystem::path show_file_picker(bool filterBoards) {
 
 	return filename;
 }
+
+const filesystem::path show_folder_picker() {
+	std::string folder;
+	NSOpenPanel *op = [NSOpenPanel openPanel];
+	[op setCanChooseFiles:NO];
+	[op setCanChooseDirectories:YES];
+	[op setAllowsMultipleSelection:NO];
+
+	if ([op runModal] == NSModalResponseOK) {
+		NSURL *nsurl = [[op URLs] objectAtIndex:0];
+		folder = std::string([[nsurl path] UTF8String]);
+	}
+
+	return folder;
+}
 #endif
 
 #ifndef ENABLE_FONTCONFIG

--- a/src/openboardview/platform.h
+++ b/src/openboardview/platform.h
@@ -24,6 +24,7 @@
 // Shows a file dialog (should hang the current thread) and returns the utf8
 // filename picked by the user.
 const filesystem::path show_file_picker(bool filterBoards = false);
+const filesystem::path show_folder_picker();
 
 const std::string get_font_path(const std::string &name);
 std::vector<char> load_font(const std::string &name);

--- a/src/openboardview/unix.cpp
+++ b/src/openboardview/unix.cpp
@@ -149,9 +149,18 @@ const filesystem::path show_file_picker(bool filterBoards) {
 
 	return path;
 }
+
+const filesystem::path show_folder_picker() {
+	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "show_folder_picker: GTK folder picker not implemented.");
+	return std::string();
+}
 #elif !defined(__APPLE__)
 const filesystem::path show_file_picker(bool filterBoards) { // dummy function when not building for OS X and GTK not available
 	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Cannot show open file dialog: not built in.");
+	return std::string();
+}
+const filesystem::path show_folder_picker() {
+	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Cannot show folder dialog: not built in.");
 	return std::string();
 }
 #endif


### PR DESCRIPTION
Implements PDF bidirectional search on macOS using [Skim](https://skim-app.sourceforge.io/) as the PDF viewer, controlled via AppleScript through `osascript`.

## Features

- **Auto-open PDF**: when a BRD file is loaded, the matching PDF is opened automatically in Skim. Lookup order: same directory as BRD → configurable `pdfDirectory` fallback
- **OBV → Skim search**: `DocumentSearch()` finds a component/net in Skim and navigates to it, cycling through multiple occurrences across pages using `find doc text … from character 1 of page N`
- **Skim → OBV search**: `HasNewSelection()` polls Skim every 2 seconds (non-blocking) for the current text selection
- **PDF folder / BRD folder settings** added to Program Preferences (previously these fields only appeared on Windows — moved outside `#ifdef _WIN32`)
- `show_folder_picker()` implemented on macOS via `NSOpenPanel` in `osx.mm`
- `PDFFile::loadFromConfig()` accepts an optional `pdfSearchDir` fallback parameter

## Implementation notes

- Uses `system("osascript /tmp/obv_skim_script.applescript")` instead of `NSAppleScript` to avoid activation/find issues
- `PDFBridgeSkim.mm` compiled with `-fobjc-arc`
- Skim must be installed (`brew install --cask skim`)

## Testing

Tested on macOS (Apple Silicon) with BRD files from `/Volumes/…/boardview/` and matching PDFs in a separate directory configured via Preferences.