### PR TITLE
macOS: Skim PDF bridge with bidirectional sync

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -158,7 +158,7 @@ int BoardView::LoadFile(const filesystem::path &filepath) {
 				auto conffilepath = filepath;
 				conffilepath.replace_extension("conf");
 				backgroundImage.loadFromConfig(conffilepath);
-				pdfFile.loadFromConfig(conffilepath);
+				pdfFile.loadFromConfig(conffilepath, filesystem::u8path(config.pdfDirectory));
 
 				pdfBridge.OpenDocument(pdfFile);
 

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -3573,7 +3573,11 @@ void BoardView::HandlePDFBridgeSelection() {
 		if (selection.empty()) {
 			m_pinHighlighted.clear();
 			m_partHighlighted.clear();
+			m_search[0][0] = '\0';
 		} else {
+			// Update search box so highlights persist across frames
+			strncpy(m_search[0], selection.c_str(), sizeof(m_search[0]) - 1);
+			m_search[0][sizeof(m_search[0]) - 1] = '\0';
 			SearchCompound(selection.c_str());
 			CenterZoomSearchResults();
 		}

--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -19,6 +19,7 @@
 #include "GUI/Preferences/BoardSettings/BoardSettings.h"
 #include "PDFBridge/PDFBridge.h"
 #include "PDFBridge/PDFBridgeEvince.h"
+#include "PDFBridge/PDFBridgeSkim.h"
 #include "PDFBridge/PDFBridgeSumatra.h"
 #include "PDFBridge/PDFFile.h"
 #include <cstdint>
@@ -64,6 +65,8 @@ struct BoardView {
 	PDFBridgeEvince pdfBridge;
 #elif defined(_WIN32)
 	PDFBridgeSumatra &pdfBridge = PDFBridgeSumatra::GetInstance(obvconfig);
+#elif defined(__APPLE__)
+	PDFBridgeSkim pdfBridge;
 #else
 	PDFBridge pdfBridge; // Dummy implementation
 #endif

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -139,7 +139,9 @@ else()
 if(APPLE)
 	set(SOURCES ${SOURCES}
 		osx.mm
+		PDFBridge/PDFBridgeSkim.mm
 	)
+	set_source_files_properties(PDFBridge/PDFBridgeSkim.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
 endif()
 	set(SOURCES ${SOURCES}
 		unix.cpp

--- a/src/openboardview/GUI/Config.cpp
+++ b/src/openboardview/GUI/Config.cpp
@@ -131,6 +131,9 @@ void Config::readFromConfig(Confparse &obvconfig) {
 	pdfSoftwarePath = obvconfig.ParseStr("pdfSoftwarePath", "SumatraPDF.exe");
 #endif
 
+	pdfDirectory = obvconfig.ParseStr("pdfDirectory", "");
+	brdDirectory = obvconfig.ParseStr("brdDirectory", "");
+
 	/*
 	 * Some machines (Atom etc) don't have enough CPU/GPU
 	 * grunt to cope with the large number of AA'd circles
@@ -212,6 +215,9 @@ void Config::writeToConfig(Confparse &obvconfig) {
 #ifdef _WIN32
 	obvconfig.WriteStr("pdfSoftwarePath", pdfSoftwarePath.c_str());
 #endif
+
+	obvconfig.WriteStr("pdfDirectory", pdfDirectory.c_str());
+	obvconfig.WriteStr("brdDirectory", brdDirectory.c_str());
 
 	obvconfig.WriteBool("slowCPU", slowCPU);
 

--- a/src/openboardview/GUI/Config.h
+++ b/src/openboardview/GUI/Config.h
@@ -57,6 +57,9 @@ public:
 	std::string pdfSoftwarePath = "";
 #endif
 
+	std::string pdfDirectory = "";
+	std::string brdDirectory = "";
+
 	template<size_t N>
 	std::array<uint32_t, N> DecodeKey(const char *keytext);
 

--- a/src/openboardview/GUI/Preferences/Program.cpp
+++ b/src/openboardview/GUI/Preferences/Program.cpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "platform.h"
+
 #include "Program.h"
 
 #include "imgui/imgui.h"
@@ -83,9 +85,39 @@ void Program::render() {
 			}
 		}
 
-#ifdef _WIN32
 		ImGui::Separator();
 
+		RightAlignedText("PDF folder", DPI(250));
+		ImGui::SameLine();
+		{
+			std::vector<char> buf(config.pdfDirectory.c_str(), config.pdfDirectory.c_str() + config.pdfDirectory.size() + 1);
+			buf.resize(32768, '\0');
+			if (ImGui::InputText("##pdfDirectory", buf.data(), buf.size()))
+				config.pdfDirectory = buf.data();
+			ImGui::SameLine();
+			if (ImGui::Button("Browse##pdfDirectory")) {
+				auto path = show_folder_picker();
+				if (!path.empty()) config.pdfDirectory = path.string();
+			}
+		}
+
+		RightAlignedText("BRD folder", DPI(250));
+		ImGui::SameLine();
+		{
+			std::vector<char> buf(config.brdDirectory.c_str(), config.brdDirectory.c_str() + config.brdDirectory.size() + 1);
+			buf.resize(32768, '\0');
+			if (ImGui::InputText("##brdDirectory", buf.data(), buf.size()))
+				config.brdDirectory = buf.data();
+			ImGui::SameLine();
+			if (ImGui::Button("Browse##brdDirectory")) {
+				auto path = show_folder_picker();
+				if (!path.empty()) config.brdDirectory = path.string();
+			}
+		}
+
+		ImGui::Separator();
+
+#ifdef _WIN32
 		RightAlignedText("PDF software executable", DPI(250));
 		ImGui::SameLine();
 

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.h
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.h
@@ -7,22 +7,33 @@
 #include "PDFFile.h"
 
 #include <string>
+#include <vector>
 #include <atomic>
+#include <thread>
+#include <mutex>
 #include <chrono>
 
 class PDFBridgeSkim : public PDFBridge {
 private:
 	std::string currentPdfPath;
-	std::string selection;
-	std::string lastPolledSelection;
+	std::vector<std::string> openedPdfPaths; // PDFs opened by OBV — closed on exit
+
+	// Background polling thread
+	std::thread pollThread;
+	std::atomic<bool> pollRunning{false};
+	std::mutex selectionMutex;
+	std::string pendingSelection;      // written by poll thread, read by main thread
+	std::atomic<bool> selectionReady{false};
+
+	std::string selection;             // last selection returned to caller
 	std::string lastSearchTerm;
 	int lastFoundPage{0};
-	std::atomic<bool> hasNewSelection{false};
-	std::chrono::steady_clock::time_point lastPollTime{};
 
 	static std::string escapeForAppleScript(const std::string &s);
 	static void runScript(const std::string &script);
 	static std::string runScriptResult(const std::string &script);
+
+	void pollLoop(); // background thread body
 
 public:
 	PDFBridgeSkim();

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.h
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.h
@@ -1,0 +1,40 @@
+#ifndef _PDFBRIDGESKIM_H_
+#define _PDFBRIDGESKIM_H_
+
+#ifdef __APPLE__
+
+#include "PDFBridge.h"
+#include "PDFFile.h"
+
+#include <string>
+#include <atomic>
+#include <chrono>
+
+class PDFBridgeSkim : public PDFBridge {
+private:
+	std::string currentPdfPath;
+	std::string selection;
+	std::string lastPolledSelection;
+	std::string lastSearchTerm;
+	int lastFoundPage{0};
+	std::atomic<bool> hasNewSelection{false};
+	std::chrono::steady_clock::time_point lastPollTime{};
+
+	static std::string escapeForAppleScript(const std::string &s);
+	static void runScript(const std::string &script);
+	static std::string runScriptResult(const std::string &script);
+
+public:
+	PDFBridgeSkim();
+	~PDFBridgeSkim();
+
+	void OpenDocument(const PDFFile &pdfFile) override;
+	void CloseDocument() override;
+	void DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive) override;
+	bool HasNewSelection() override;
+	std::string GetSelection() const override;
+};
+
+#endif // __APPLE__
+
+#endif // _PDFBRIDGESKIM_H_

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.mm
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.mm
@@ -1,0 +1,161 @@
+#include "PDFBridgeSkim.h"
+
+#ifdef __APPLE__
+
+#import <Foundation/Foundation.h>
+#include <SDL.h>
+
+PDFBridgeSkim::PDFBridgeSkim() {}
+PDFBridgeSkim::~PDFBridgeSkim() {}
+
+std::string PDFBridgeSkim::escapeForAppleScript(const std::string &s) {
+	std::string result;
+	for (char c : s) {
+		if (c == '"') result += "\\\"";
+		else result += c;
+	}
+	return result;
+}
+
+void PDFBridgeSkim::runScript(const std::string &script) {
+	// Write script to temp file and run with osascript
+	std::string tmpFile = "/tmp/obv_skim_script.applescript";
+	FILE *f = fopen(tmpFile.c_str(), "w");
+	if (!f) return;
+	fwrite(script.c_str(), 1, script.size(), f);
+	fclose(f);
+	std::string cmd = "osascript " + tmpFile + " &>/dev/null &";
+	system(cmd.c_str());
+}
+
+std::string PDFBridgeSkim::runScriptResult(const std::string &script) {
+	std::string tmpFile = "/tmp/obv_skim_query.applescript";
+	FILE *f = fopen(tmpFile.c_str(), "w");
+	if (!f) return "";
+	fwrite(script.c_str(), 1, script.size(), f);
+	fclose(f);
+	std::string cmd = "osascript " + tmpFile + " 2>/dev/null";
+	FILE *pipe = popen(cmd.c_str(), "r");
+	if (!pipe) return "";
+	char buf[512];
+	std::string result;
+	while (fgets(buf, sizeof(buf), pipe)) result += buf;
+	pclose(pipe);
+	if (!result.empty() && result.back() == '\n') result.pop_back();
+	return result;
+}
+
+void PDFBridgeSkim::OpenDocument(const PDFFile &pdfFile) {
+	auto pdfPath = pdfFile.getPath();
+	if (!filesystem::exists(pdfPath)) {
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: PDF file does not exist: %s",
+			pdfPath.generic_string().c_str());
+		return;
+	}
+
+	currentPdfPath = filesystem::canonical(pdfPath).string();
+	std::string escaped = escapeForAppleScript(currentPdfPath);
+
+	std::string script =
+		"tell application \"Skim\"\n"
+		"    activate\n"
+		"    open POSIX file \"" + escaped + "\"\n"
+		"end tell";
+
+	runScript(script);
+	SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim: opened %s", currentPdfPath.c_str());
+}
+
+void PDFBridgeSkim::CloseDocument() {
+	currentPdfPath = "";
+}
+
+void PDFBridgeSkim::DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive) {
+	if (currentPdfPath.empty()) {
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: no document open");
+		return;
+	}
+
+	std::string escaped = escapeForAppleScript(str);
+
+	std::string docName = filesystem::path(currentPdfPath).filename().string();
+	std::string escapedDoc = escapeForAppleScript(docName);
+	std::string caseSens = caseSensitive ? " case sensitive search yes" : "";
+
+	bool sameTerm = (str == lastSearchTerm);
+	lastSearchTerm = str;
+
+	// Aynı terme tekrar basılınca son bulunan sayfadan sonrasından ara
+	// Farklı terme basılınca baştan başla
+	std::string fromClause;
+	if (sameTerm && lastFoundPage > 0) {
+		fromClause = " from character 1 of page " + std::to_string(lastFoundPage + 1) + " of doc";
+	} else {
+		fromClause = " from character 1 of page 1 of doc";
+		lastFoundPage = 0;
+	}
+
+	std::string script =
+		"tell application \"Skim\"\n"
+		"    activate\n"
+		"    set doc to document \"" + escapedDoc + "\"\n"
+		"    set r to find doc text \"" + escaped + "\"" + fromClause + caseSens + "\n"
+		"    if (count of r) > 0 then\n"
+		"        set selection of doc to r\n"
+		"        go doc to item 1 of r\n"
+		"        return index of current page of doc\n"
+		"    else\n"
+		"        return 0\n"
+		"    end if\n"
+		"end tell";
+
+	std::string result = runScriptResult(script);
+	if (!result.empty() && result != "0") {
+		try { lastFoundPage = std::stoi(result); } catch (...) {}
+	} else if (result == "0" && sameTerm && lastFoundPage > 0) {
+		// Sona gelindi, başa dön
+		lastFoundPage = 0;
+		DocumentSearch(str, wholeWordsOnly, caseSensitive);
+		return;
+	}
+	SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim: searching for '%s' page=%s", str.c_str(), result.c_str());
+}
+
+bool PDFBridgeSkim::HasNewSelection() {
+	if (currentPdfPath.empty()) return false;
+
+	// Poll at most every 2 seconds to avoid freezing the UI
+	auto now = std::chrono::steady_clock::now();
+	if (std::chrono::duration_cast<std::chrono::seconds>(now - lastPollTime).count() < 2)
+		return false;
+	lastPollTime = now;
+
+	// Poll Skim's current text selection for reverse search
+	std::string script =
+		"tell application \"Skim\"\n"
+		"    if (count of documents) > 0 then\n"
+		"        set sel to selection of front document\n"
+		"        if sel is not missing value then\n"
+		"            return string of sel\n"
+		"        end if\n"
+		"    end if\n"
+		"    return \"\"\n"
+		"end tell";
+
+	std::string polled = runScriptResult(script);
+
+	if (!polled.empty() && polled != lastPolledSelection) {
+		lastPolledSelection = polled;
+		selection = polled;
+		hasNewSelection = true;
+		return true;
+	}
+
+	return false;
+}
+
+std::string PDFBridgeSkim::GetSelection() const {
+	return selection;
+}
+
+#endif // __APPLE__

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.mm
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.mm
@@ -4,9 +4,9 @@
 
 #import <Foundation/Foundation.h>
 #include <SDL.h>
+#include <cctype>
 
-PDFBridgeSkim::PDFBridgeSkim() {}
-PDFBridgeSkim::~PDFBridgeSkim() {}
+// ---------- helpers ----------
 
 std::string PDFBridgeSkim::escapeForAppleScript(const std::string &s) {
 	std::string result;
@@ -18,7 +18,6 @@ std::string PDFBridgeSkim::escapeForAppleScript(const std::string &s) {
 }
 
 void PDFBridgeSkim::runScript(const std::string &script) {
-	// Write script to temp file and run with osascript
 	std::string tmpFile = "/tmp/obv_skim_script.applescript";
 	FILE *f = fopen(tmpFile.c_str(), "w");
 	if (!f) return;
@@ -45,6 +44,101 @@ std::string PDFBridgeSkim::runScriptResult(const std::string &script) {
 	return result;
 }
 
+// ---------- background polling thread ----------
+
+// Trim whitespace from both ends
+static std::string trimWS(const std::string &s) {
+	size_t start = s.find_first_not_of(" \t\n\r");
+	if (start == std::string::npos) return "";
+	size_t end = s.find_last_not_of(" \t\n\r");
+	return s.substr(start, end - start + 1);
+}
+
+
+void PDFBridgeSkim::pollLoop() {
+	std::string lastSeen;
+
+	while (pollRunning.load()) {
+		// 1) Check the Automator request file first (instant, no AppleScript cost)
+		{
+			const char *reqFile = "/tmp/obv_search_request.txt";
+			FILE *f = fopen(reqFile, "r");
+			if (f) {
+				char buf[512] = {};
+				fgets(buf, sizeof(buf), f);
+				fclose(f);
+				remove(reqFile);
+				std::string req = trimWS(std::string(buf));
+				if (!req.empty() && req != lastSeen) {
+					lastSeen = req;
+					std::lock_guard<std::mutex> lk(selectionMutex);
+					pendingSelection = req;
+					selectionReady.store(true);
+				}
+				std::this_thread::sleep_for(std::chrono::milliseconds(200));
+				continue;
+			}
+		}
+
+		// 2) Poll Skim's current text selection via AppleScript
+		std::string script =
+			"tell application \"Skim\"\n"
+			"    if (count of documents) > 0 then\n"
+			"        set sel to selection of front document\n"
+			"        if sel is not missing value then\n"
+			"            set txt to \"\"\n"
+			"            repeat with s in sel\n"
+			"                set txt to txt & (s as string)\n"
+			"            end repeat\n"
+			"            return txt\n"
+			"        end if\n"
+			"    end if\n"
+			"    return \"\"\n"
+			"end tell";
+
+		std::string polled = trimWS(runScriptResult(script));
+
+		if (!polled.empty() && polled != lastSeen) {
+			lastSeen = polled;
+			std::lock_guard<std::mutex> lk(selectionMutex);
+			pendingSelection = polled;
+			selectionReady.store(true);
+		} else if (polled.empty()) {
+			lastSeen = ""; // reset so next selection triggers even if same text
+		}
+
+		// Poll every 500 ms
+		std::this_thread::sleep_for(std::chrono::milliseconds(500));
+	}
+}
+
+// ---------- lifecycle ----------
+
+PDFBridgeSkim::PDFBridgeSkim() {
+	pollRunning.store(true);
+	pollThread = std::thread(&PDFBridgeSkim::pollLoop, this);
+}
+
+PDFBridgeSkim::~PDFBridgeSkim() {
+	pollRunning.store(false);
+	if (pollThread.joinable()) pollThread.detach(); // don't block — thread dies with process
+
+	// Close only the documents that OBV opened (synchronous)
+	for (const auto &path : openedPdfPaths) {
+		std::string docName = filesystem::path(path).filename().string();
+		std::string escapedDoc = escapeForAppleScript(docName);
+		std::string script =
+			"tell application \"Skim\"\n"
+			"    try\n"
+			"        close document \"" + escapedDoc + "\"\n"
+			"    end try\n"
+			"end tell";
+		runScriptResult(script);
+	}
+}
+
+// ---------- public API ----------
+
 void PDFBridgeSkim::OpenDocument(const PDFFile &pdfFile) {
 	auto pdfPath = pdfFile.getPath();
 	if (!filesystem::exists(pdfPath)) {
@@ -63,6 +157,7 @@ void PDFBridgeSkim::OpenDocument(const PDFFile &pdfFile) {
 		"end tell";
 
 	runScript(script);
+	openedPdfPaths.push_back(currentPdfPath);
 	SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim: opened %s", currentPdfPath.c_str());
 }
 
@@ -85,8 +180,6 @@ void PDFBridgeSkim::DocumentSearch(const std::string &str, bool wholeWordsOnly, 
 	bool sameTerm = (str == lastSearchTerm);
 	lastSearchTerm = str;
 
-	// Aynı terme tekrar basılınca son bulunan sayfadan sonrasından ara
-	// Farklı terme basılınca baştan başla
 	std::string fromClause;
 	if (sameTerm && lastFoundPage > 0) {
 		fromClause = " from character 1 of page " + std::to_string(lastFoundPage + 1) + " of doc";
@@ -113,7 +206,6 @@ void PDFBridgeSkim::DocumentSearch(const std::string &str, bool wholeWordsOnly, 
 	if (!result.empty() && result != "0") {
 		try { lastFoundPage = std::stoi(result); } catch (...) {}
 	} else if (result == "0" && sameTerm && lastFoundPage > 0) {
-		// Sona gelindi, başa dön
 		lastFoundPage = 0;
 		DocumentSearch(str, wholeWordsOnly, caseSensitive);
 		return;
@@ -122,36 +214,11 @@ void PDFBridgeSkim::DocumentSearch(const std::string &str, bool wholeWordsOnly, 
 }
 
 bool PDFBridgeSkim::HasNewSelection() {
-	if (currentPdfPath.empty()) return false;
-
-	// Poll at most every 2 seconds to avoid freezing the UI
-	auto now = std::chrono::steady_clock::now();
-	if (std::chrono::duration_cast<std::chrono::seconds>(now - lastPollTime).count() < 2)
-		return false;
-	lastPollTime = now;
-
-	// Poll Skim's current text selection for reverse search
-	std::string script =
-		"tell application \"Skim\"\n"
-		"    if (count of documents) > 0 then\n"
-		"        set sel to selection of front document\n"
-		"        if sel is not missing value then\n"
-		"            return string of sel\n"
-		"        end if\n"
-		"    end if\n"
-		"    return \"\"\n"
-		"end tell";
-
-	std::string polled = runScriptResult(script);
-
-	if (!polled.empty() && polled != lastPolledSelection) {
-		lastPolledSelection = polled;
-		selection = polled;
-		hasNewSelection = true;
-		return true;
-	}
-
-	return false;
+	if (!selectionReady.load()) return false;
+	std::lock_guard<std::mutex> lk(selectionMutex);
+	selection = pendingSelection;
+	selectionReady.store(false);
+	return true;
 }
 
 std::string PDFBridgeSkim::GetSelection() const {

--- a/src/openboardview/PDFBridge/PDFFile.cpp
+++ b/src/openboardview/PDFBridge/PDFFile.cpp
@@ -24,15 +24,21 @@ void PDFFile::close() {
 	this->pdfBridge->CloseDocument();
 }
 
-void PDFFile::loadFromConfig(const filesystem::path &filepath) {
+void PDFFile::loadFromConfig(const filesystem::path &filepath, const filesystem::path &pdfSearchDir) {
 	configFilepath = filepath; // save filepath for latter use with writeToConfig
 
 	// Use boardview file path as default PDF file path, with ext replaced with .pdf
 	path = filepath;
 	path.replace_extension("pdf");
 
-	if (!filesystem::exists(filepath)) { // Config file doesn't exist, do not attempt to read or write it and load images
+	if (!filesystem::exists(filepath)) { // Config file doesn't exist
 		SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Board configuration file %s does not exist", filepath.generic_string().c_str());
+		// pdfSearchDir varsa yine de kontrol et
+		if (!pdfSearchDir.empty()) {
+			auto candidate = pdfSearchDir / path.filename();
+			if (filesystem::exists(candidate))
+				path = candidate;
+		}
 		return;
 	}
 
@@ -47,6 +53,13 @@ void PDFFile::loadFromConfig(const filesystem::path &filepath) {
 	std::string pdfFilePathStr{confparse.ParseStr("PDFFilePath", "")};
 	if (!pdfFilePathStr.empty())
 		path = configDir/filesystem::u8path(pdfFilePathStr);
+
+	// Eğer PDF bulunamadıysa ve pdfSearchDir tanımlıysa orada ara
+	if (!filesystem::exists(path) && !pdfSearchDir.empty()) {
+		auto candidate = pdfSearchDir / path.filename();
+		if (filesystem::exists(candidate))
+			path = candidate;
+	}
 
 	writeToConfig(filepath);
 }

--- a/src/openboardview/PDFBridge/PDFFile.h
+++ b/src/openboardview/PDFBridge/PDFFile.h
@@ -33,7 +33,7 @@ public:
 	void reload();
 	void close();
 
-	void loadFromConfig(const filesystem::path &filepath);
+	void loadFromConfig(const filesystem::path &filepath, const filesystem::path &pdfSearchDir = {});
 	void writeToConfig(const filesystem::path &filepath);
 	filesystem::path getPath() const;
 

--- a/src/openboardview/main_opengl.cpp
+++ b/src/openboardview/main_opengl.cpp
@@ -449,6 +449,17 @@ int main(int argc, char **argv) {
 			usleep(50000);
 #endif
 			sleepout = 0;
+			// Wake up if the background Skim poll thread found a new selection
+			if (app.pdfBridge.HasNewSelection()) {
+				auto sel = app.pdfBridge.GetSelection();
+				if (!sel.empty()) {
+					strncpy(app.m_search[0], sel.c_str(), sizeof(app.m_search[0]) - 1);
+					app.m_search[0][sizeof(app.m_search[0]) - 1] = '\0';
+					app.SearchCompound(sel.c_str());
+					app.CenterZoomSearchResults();
+				}
+				sleepout = 5; // render a few frames to show the result
+			}
 			continue;
 		} // puts OBV to sleep if nothing is happening.
 		// Prepare frame
@@ -493,11 +504,11 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	// Cleanup
+	// Cleanup — do NOT use cleanupAndExit here: exit() skips C++ destructors
+	// (PDFBridgeSkim destructor must run to close Skim and stop the poll thread)
 	Renderers::current->shutdown();
-
 	ImGui::DestroyContext();
-
-	cleanupAndExit(0);
+	if (window) SDL_DestroyWindow(window);
+	SDL_Quit();
 	return 0;
 }

--- a/src/openboardview/osx.mm
+++ b/src/openboardview/osx.mm
@@ -18,6 +18,21 @@ const filesystem::path show_file_picker(bool filterBoards) {
 
 	return filename;
 }
+
+const filesystem::path show_folder_picker() {
+	std::string folder;
+	NSOpenPanel *op = [NSOpenPanel openPanel];
+	[op setCanChooseFiles:NO];
+	[op setCanChooseDirectories:YES];
+	[op setAllowsMultipleSelection:NO];
+
+	if ([op runModal] == NSModalResponseOK) {
+		NSURL *nsurl = [[op URLs] objectAtIndex:0];
+		folder = std::string([[nsurl path] UTF8String]);
+	}
+
+	return folder;
+}
 #endif
 
 #ifndef ENABLE_FONTCONFIG

--- a/src/openboardview/platform.h
+++ b/src/openboardview/platform.h
@@ -24,6 +24,7 @@
 // Shows a file dialog (should hang the current thread) and returns the utf8
 // filename picked by the user.
 const filesystem::path show_file_picker(bool filterBoards = false);
+const filesystem::path show_folder_picker();
 
 const std::string get_font_path(const std::string &name);
 std::vector<char> load_font(const std::string &name);

--- a/src/openboardview/unix.cpp
+++ b/src/openboardview/unix.cpp
@@ -149,9 +149,18 @@ const filesystem::path show_file_picker(bool filterBoards) {
 
 	return path;
 }
+
+const filesystem::path show_folder_picker() {
+	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "show_folder_picker: GTK folder picker not implemented.");
+	return std::string();
+}
 #elif !defined(__APPLE__)
 const filesystem::path show_file_picker(bool filterBoards) { // dummy function when not building for OS X and GTK not available
 	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Cannot show open file dialog: not built in.");
+	return std::string();
+}
+const filesystem::path show_folder_picker() {
+	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Cannot show folder dialog: not built in.");
 	return std::string();
 }
 #endif


### PR DESCRIPTION
## Summary
- Adds `PDFBridgeSkim` — a macOS-specific PDF bridge using Skim via AppleScript
- **Skim → OBV**: selecting text in Skim automatically searches and highlights the component in OBV (~500ms latency, background thread, no UI blocking)
- **OBV → Skim**: clicking PDF Search in OBV opens the matching schematic in Skim and navigates to the component
- **Auto-close**: Skim documents opened by OBV are closed when OBV exits
- Fix `exit()` → `return` in main loop so C++ destructors run on quit

## Technical details
- Background polling thread reads Skim's text selection every 500ms via AppleScript
- Also monitors `/tmp/obv_search_request.txt` for integration with macOS Services (right-click menu)
- Fixed AppleScript selection extraction: use `repeat with s in sel` instead of `string of sel`
- Search result written to `m_search[0]` so highlights persist across render frames
- Thread is detached on exit; Skim close script runs synchronously before process ends

## Test plan
- [ ] Open a BRD in OBV — matching PDF opens in Skim automatically
- [ ] Select a component name in Skim — OBV highlights it within ~1 second
- [ ] Click PDF Search in OBV — Skim navigates to the component
- [ ] Close OBV — Skim documents opened by OBV close automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)