### PR TITLE
gencad: fixup "deduplicating" elements placed on opposite sides

### DIFF
--- a/src/openboardview/FileFormats/GenCADFile.cpp
+++ b/src/openboardview/FileFormats/GenCADFile.cpp
@@ -214,7 +214,7 @@ bool GenCADFile::parse_components() {
 			if (shape_ref_ast) {
 				char *shape_name_str = get_nonquoted_or_quoted_string_child(shape_ref_ast, "shape_name");
 				if (shape_name_str && *shape_name_str) {
-					PositionedNamedShape duplicate_check_id{brd_part.p1.x, brd_part.p1.y, shape_name_str};
+					PositionedNamedShape duplicate_check_id{brd_part.mounting_side, brd_part.p1.x, brd_part.p1.y, shape_name_str};
 					if (!m_parsed_shapes.insert(duplicate_check_id).second)
 					{
 						i++;

--- a/src/openboardview/FileFormats/GenCADFile.h
+++ b/src/openboardview/FileFormats/GenCADFile.h
@@ -89,7 +89,7 @@ class GenCADFile : public BRDFileBase {
 	std::map<std::string, PadStackInfo> m_pad_stack_info_cache;
 
 	// stores all loaded shapes to perform duplicate detection
-	typedef std::tuple<int, int, std::string> PositionedNamedShape;
+	typedef std::tuple<BRDPartMountingSide, int, int, std::string> PositionedNamedShape;
 	std::set<PositionedNamedShape> m_parsed_shapes;
 	int nc_counter = 0;
 


### PR DESCRIPTION
Problem was introduced by too aggressive deduplication I've done in edddcff89f504fb4919ca042c090d7b3b68ce5a5

Fixed by differentiating sides while seeking for duplicates

User-visible effect: identical elements placed exactly simmetrially on opposite PCB sides (typical for RAM ICs) was shown only on one side. Other boards was not affected 