### PR TITLE
board loading: enable per-component pad sorting common for all formats

### DIFF
--- a/src/openboardview/BRDBoard.cpp
+++ b/src/openboardview/BRDBoard.cpp
@@ -2,6 +2,7 @@
 
 #include "FileFormats/BRDFile.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <fstream>
 #include <functional>
@@ -212,6 +213,11 @@ BRDBoard::BRDBoard(const BRDFileBase * const boardFile)
 		components_.erase(
 		    remove_if(begin(components_), end(components_), [](std::shared_ptr<Component> &comp) { return comp->is_dummy(); }),
 		    end(components_));
+
+		// sort pins according to BGA pin naming
+		for (auto &component: components_) {
+		  std::stable_sort(component->pins.begin(), component->pins.end(), Pin::LessByNumberAndName());
+		}
 
 		components_.push_back(comp_dummy);
 	}

--- a/src/openboardview/Board.cpp
+++ b/src/openboardview/Board.cpp
@@ -1,4 +1,38 @@
 #include "Board.h"
+#include <cctype>
+#include <cstdlib>
+
+#include <tuple>
+
+struct ParsedPinString {
+	std::string non_digit_prefix;
+	int digits_value = {};
+
+	ParsedPinString(const std::string &s)
+		// convert digits after the prefix to int; if there are no digits atoi would be called on terminating '\0' and safely return 0
+		: non_digit_prefix(begin(s), std::find_if(begin(s), end(s), isdigit))
+		, digits_value(atoi(&s[non_digit_prefix.size()])) {}
+};
+
+std::tuple<std::size_t, std::string, int, int> make_pin_ordering_tuple(const Pin &pin) {
+	// The wanted order for BGA pins looks like:
+	// A0 A1..A9 A10 A11..A99 A100 A101..B0..Z0..AA0..AZ0..BA0..
+	// Information from both `number` and `name` fields is used, but `number` has precedence.
+	ParsedPinString number{pin.number};
+	ParsedPinString name{pin.name};
+	std::string non_digit_text{number.non_digit_prefix.empty() ? name.non_digit_prefix : number.non_digit_prefix};
+
+	// To implement the BGA pins ordering mentioned above return a tuple (used as a comparison key) with the following precedence:
+	// text length, text ascii, digits from `number`, digits from `name`
+	return {non_digit_text.size(), non_digit_text, number.digits_value, name.digits_value};
+}
+
+bool Pin::LessByNumberAndName::operator()(const std::shared_ptr<Pin> &a, const std::shared_ptr<Pin> &b) const {
+	// Caller must ensure that shared_ptr arguments are non-nullptr (used only for indirection, not for optionality).
+	// This comparison operator MUST satisfy the strict weak ordering definition; otherwise std::sort can crash!
+	// Using tuple as keys with their default comparison helps ensure this invariant.
+	return make_pin_ordering_tuple(*a) < make_pin_ordering_tuple(*b);
+}
 
 std::vector<const std::string *> Component::searchableStringDetails() const {
 	return {&mfgcode};

--- a/src/openboardview/Board.h
+++ b/src/openboardview/Board.h
@@ -143,6 +143,9 @@ struct Pin : BoardElement {
 	std::string UniqueId() const {
 		return kBoardPinPrefix + number;
 	}
+	struct LessByNumberAndName {
+		bool operator()(const std::shared_ptr<Pin> &a, const std::shared_ptr<Pin> &b) const;
+	};
 };
 
 // A component on the board having multiple Pins.

--- a/src/openboardview/FileFormats/ADFile.cpp
+++ b/src/openboardview/FileFormats/ADFile.cpp
@@ -482,7 +482,6 @@ ADFile::ADFile(std::vector<char> &buf) {
 		parts.push_back(part);
 	}
 
-	std::sort(pins.begin(), pins.end(), customLess);
 
 	num_parts  = parts.size();
 	num_pins   = pins.size();

--- a/src/openboardview/FileFormats/ADFile.h
+++ b/src/openboardview/FileFormats/ADFile.h
@@ -36,13 +36,6 @@ struct AD_BRDPad {
 struct ADFile : public BRDFileBase {
 	ADFile(std::vector<char> &buf);
 
-	struct {
-		bool operator()(BRDPin a, BRDPin b) const {
-			char *pEnd;
-			return strtod(a.snum, &pEnd) < strtod(b.snum, &pEnd);
-		}
-	} customLess;
-
 	std::vector<AD_BRDNet> ad_nets;
 	std::vector<AD_BRDPart> ad_parts;
 	std::vector<AD_BRDPad> ad_pads;

--- a/src/openboardview/FileFormats/BRDFileBase.h
+++ b/src/openboardview/FileFormats/BRDFileBase.h
@@ -71,11 +71,6 @@ struct BRDPin {
 	double radius    = 0.5f;
 	const char *snum = nullptr;
 	const char *name = nullptr;
-
-	bool operator<(const BRDPin &p) const // For sorting the vector
-	{
-		return part == p.part ? (std::string(snum) < std::string(p.snum)) : (part < p.part); // sort by part number then pin number
-	}
 };
 
 struct BRDNail {


### PR DESCRIPTION
Pins are sorted by text part, then by numeric part. A special ordering function is implemented to order pins of large BGAs as A0 A1..A9 A10 A11..A99 A100 A101..B0..Z0..AA0..AZ0..BA0..