### PR TITLE
Add a macOS PDF bridge backend (Skim)

### DIFF
--- a/asset/MacOSXBundleInfo.plist.in
+++ b/asset/MacOSXBundleInfo.plist.in
@@ -32,5 +32,7 @@
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>OpenBoardView controls a PDF viewer (Skim) to search the schematic for the selected component.</string>
 </dict>
 </plist>

--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -20,6 +20,7 @@
 #include "PDFBridge/PDFBridge.h"
 #include "PDFBridge/PDFBridgeEvince.h"
 #include "PDFBridge/PDFBridgeSumatra.h"
+#include "PDFBridge/PDFBridgeSkim.h"
 #include "PDFBridge/PDFFile.h"
 #include <cstdint>
 #include <vector>
@@ -64,6 +65,8 @@ struct BoardView {
 	PDFBridgeEvince pdfBridge;
 #elif defined(_WIN32)
 	PDFBridgeSumatra &pdfBridge = PDFBridgeSumatra::GetInstance(obvconfig);
+#elif defined(ENABLE_PDFBRIDGE_SKIM)
+	PDFBridgeSkim pdfBridge{obvconfig};
 #else
 	PDFBridge pdfBridge; // Dummy implementation
 #endif

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
 		find_library(COCOA_LIBRARY Cocoa)
 		find_package(OpenGL REQUIRED)
 		set(OPENGL_INCLUDE_DIR ${OPENGL_INCLUDE_DIR}/Headers)
+		add_definitions(-DENABLE_PDFBRIDGE_SKIM) # macOS PDF bridge via Skim
 	else(APPLE)
 		find_package(PkgConfig REQUIRED)
 
@@ -139,7 +140,10 @@ else()
 if(APPLE)
 	set(SOURCES ${SOURCES}
 		osx.mm
+		PDFBridge/PDFBridgeSkim.mm
 	)
+	# PDFBridgeSkim uses ARC; the rest of the ObjC++ (osx.mm) is manual retain/release.
+	set_source_files_properties(PDFBridge/PDFBridgeSkim.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
 endif()
 	set(SOURCES ${SOURCES}
 		unix.cpp

--- a/src/openboardview/PDFBridge/PDFBridge.cpp
+++ b/src/openboardview/PDFBridge/PDFBridge.cpp
@@ -1,9 +1,12 @@
 #include "PDFBridge.h"
 
+#include <SDL.h>
+
 PDFBridge::~PDFBridge() {
 }
 
 bool PDFBridge::HasNewSelection() {
+	// Called every frame from the render loop, so stay silent here to avoid log spam.
 	return false;
 }
 
@@ -12,10 +15,16 @@ std::string PDFBridge::GetSelection() const {
 }
 
 void PDFBridge::OpenDocument(const PDFFile &pdfFile) {
+	SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+	            "PDFBridge: no PDF bridge backend is available on this platform; "
+	            "boardview <-> schematic cross-probing is disabled.");
 }
 
 void PDFBridge::CloseDocument() {
 }
 
 void PDFBridge::DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive) {
+	SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+	            "PDFBridge: cannot search the schematic for \"%s\" -- no PDF bridge backend "
+	            "on this platform.", str.c_str());
 }

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.h
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.h
@@ -1,0 +1,55 @@
+#ifndef _PDFBRIDGESKIM_H_
+#define _PDFBRIDGESKIM_H_
+
+#ifdef ENABLE_PDFBRIDGE_SKIM
+
+#include "PDFBridge.h"
+#include "PDFFile.h"
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "confparse.h"
+
+// macOS PDF bridge driving Skim (https://skim-app.sourceforge.io/) over AppleScript.
+// Mirrors the PDFBridgeEvince lifecycle: lazy use in OpenDocument, path canonicalisation,
+// existence check before load, and SDL_LogError on every failure path.
+//
+// Forward search (OBV -> Skim) runs synchronously on the caller/render thread, which is
+// fine because it only fires on a button press. Reverse search (Skim -> OBV) reads Skim's
+// text selection on a background thread at a configurable interval and stores it under a
+// mutex; HasNewSelection()/GetSelection() -- called every frame from the render loop --
+// only touch the cached value and never block on AppleScript.
+class PDFBridgeSkim : public PDFBridge {
+private:
+	std::string appName; // Skim application name, configurable via obvConfig ("pdfSkimApplication")
+	std::string pdfPath; // canonical path of the currently-open PDF, empty if none
+
+	// Reverse-search polling. pollIntervalMs <= 0 disables reverse search entirely.
+	int pollIntervalMs = 0;
+	std::thread pollThread;
+	std::atomic<bool> pollRunning{false};
+	mutable std::mutex selectionMutex;
+	std::string currentSelection;  // guarded by selectionMutex
+	bool selectionChanged = false; // guarded by selectionMutex
+
+	void startPolling();
+	void stopPolling();
+	void pollLoop();
+
+public:
+	PDFBridgeSkim(Confparse &obvConfig);
+	~PDFBridgeSkim();
+
+	void OpenDocument(const PDFFile &pdfFile);
+	void CloseDocument();
+	void DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive);
+	bool HasNewSelection();
+	std::string GetSelection() const;
+};
+
+#endif // ENABLE_PDFBRIDGE_SKIM
+
+#endif //_PDFBRIDGESKIM_H_

--- a/src/openboardview/PDFBridge/PDFBridgeSkim.mm
+++ b/src/openboardview/PDFBridge/PDFBridgeSkim.mm
@@ -1,0 +1,289 @@
+#include "PDFBridgeSkim.h"
+
+#ifdef ENABLE_PDFBRIDGE_SKIM
+
+#import <Foundation/Foundation.h>
+
+#include <SDL.h>
+
+#include <algorithm>
+#include <chrono>
+
+#include "filesystem_impl.h"
+
+namespace {
+
+// Escape a string for embedding inside an AppleScript double-quoted string literal.
+std::string escapeForAppleScript(const std::string &in) {
+	std::string out;
+	out.reserve(in.size());
+	for (char c : in) {
+		if (c == '\\' || c == '"')
+			out.push_back('\\');
+		out.push_back(c);
+	}
+	return out;
+}
+
+NSString *toNSString(const std::string &in) {
+	NSString *s = [NSString stringWithUTF8String:in.c_str()];
+	return s != nil ? s : @"";
+}
+
+// Compile and run an AppleScript source string via NSAppleScript, returning the script's
+// string result ("" on error or no result). NSAppleScript is main-thread affine, so this
+// must only be called from the render/main thread (which is where OBV invokes the bridge).
+std::string runAppleScript(NSString *source) {
+	@autoreleasepool {
+		NSAppleScript *script = [[NSAppleScript alloc] initWithSource:source];
+		if (script == nil) {
+			SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: failed to compile AppleScript");
+			return {};
+		}
+
+		NSDictionary *errorInfo = nil;
+		NSAppleEventDescriptor *result = [script executeAndReturnError:&errorInfo];
+
+		if (errorInfo != nil) {
+			NSNumber *errNum = errorInfo[NSAppleScriptErrorNumber];
+			NSString *errMsg = errorInfo[NSAppleScriptErrorMessage];
+			if (errNum != nil && [errNum intValue] == errAEEventNotPermitted) {
+				// This is the silent-failure trap #285 hit: without automation consent the
+				// Apple Event is refused. Surface it instead of failing quietly.
+				SDL_LogError(SDL_LOG_CATEGORY_ERROR,
+				             "PDFBridgeSkim: automation permission denied. Allow OpenBoardView "
+				             "to control Skim under System Settings > Privacy & Security > "
+				             "Automation, then try again.");
+			} else {
+				SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim AppleScript error: %s",
+				             errMsg != nil ? [errMsg UTF8String] : "unknown");
+			}
+			return {};
+		}
+
+		if (result != nil && [result stringValue] != nil)
+			return std::string([[result stringValue] UTF8String]);
+		return {};
+	}
+}
+
+// Wrap an operation in a script that resolves `theDoc` to our PDF -- matching an already
+// open document by path, or opening it in Skim on demand. This keeps every operation
+// robust to the user having closed the window and to other PDFs being open (so we never
+// act on the wrong `document 1`). `body` is AppleScript operating on `theDoc`.
+NSString *scriptForDocument(const std::string &appName, const std::string &pdfPath, NSString *body) {
+	return [NSString stringWithFormat:
+		@"tell application \"%@\"\n"
+		 "\tactivate\n"
+		 "\tset thePath to \"%@\"\n"
+		 "\tset theDoc to missing value\n"
+		 "\trepeat with d in documents\n"
+		 "\t\tif (path of d) is thePath then\n"
+		 "\t\t\tset theDoc to d\n"
+		 "\t\t\texit repeat\n"
+		 "\t\tend if\n"
+		 "\tend repeat\n"
+		 "\tif theDoc is missing value then\n"
+		 "\t\topen POSIX file thePath\n"
+		 "\t\trepeat with d in documents\n"
+		 "\t\t\tif (path of d) is thePath then\n"
+		 "\t\t\t\tset theDoc to d\n"
+		 "\t\t\t\texit repeat\n"
+		 "\t\t\tend if\n"
+		 "\t\tend repeat\n"
+		 "\tend if\n"
+		 "\tif theDoc is missing value then error \"could not open document\"\n"
+		 "%@\n"
+		 "end tell",
+		toNSString(escapeForAppleScript(appName)),
+		toNSString(escapeForAppleScript(pdfPath)),
+		body];
+}
+
+// Build the read-only script used by the reverse-search poll: find our document by path
+// (WITHOUT opening it or activating Skim -- a background poll must never steal focus or
+// resurrect a window the user closed) and return the current selection's text, or "".
+NSString *selectionQueryScript(const std::string &appName, const std::string &pdfPath) {
+	return [NSString stringWithFormat:
+		@"tell application \"%@\"\n"
+		 "\tset thePath to \"%@\"\n"
+		 "\tset theDoc to missing value\n"
+		 "\trepeat with d in documents\n"
+		 "\t\tif (path of d) is thePath then\n"
+		 "\t\t\tset theDoc to d\n"
+		 "\t\t\texit repeat\n"
+		 "\t\tend if\n"
+		 "\tend repeat\n"
+		 "\tif theDoc is missing value then return \"\"\n"
+		 "\ttry\n"
+		 "\t\treturn (obtain text for (selection of theDoc)) as string\n"
+		 "\ton error\n"
+		 "\t\treturn \"\"\n"
+		 "\tend try\n"
+		 "end tell",
+		toNSString(escapeForAppleScript(appName)),
+		toNSString(escapeForAppleScript(pdfPath))];
+}
+
+// Run an AppleScript via the `osascript` subprocess and return its trimmed stdout. Used
+// only from the background poll thread: NSAppleScript is main-thread affine, whereas a
+// subprocess is safe to drive from any thread. TCC attributes the Apple Events to the
+// responsible process (OpenBoardView), so the app's existing automation grant covers it.
+std::string runOsascript(NSString *source) {
+	@autoreleasepool {
+		NSTask *task = [[NSTask alloc] init];
+		task.launchPath = @"/usr/bin/osascript";
+		task.arguments = @[ @"-e", source ];
+		NSPipe *outPipe = [NSPipe pipe];
+		task.standardOutput = outPipe;
+		task.standardError = [NSPipe pipe]; // swallow errors; poll stays quiet to avoid log spam
+
+		@try {
+			[task launch];
+		} @catch (NSException *e) {
+			return {};
+		}
+
+		// Read before waiting to avoid deadlocking on a full pipe buffer.
+		NSData *data = [[outPipe fileHandleForReading] readDataToEndOfFile];
+		[task waitUntilExit];
+
+		NSString *out = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+		if (out == nil)
+			return {};
+		out = [out stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+		return std::string([out UTF8String]);
+	}
+}
+
+} // namespace
+
+PDFBridgeSkim::PDFBridgeSkim(Confparse &obvConfig) {
+	appName = obvConfig.ParseStr("pdfSkimApplication", "Skim");
+	pollIntervalMs = obvConfig.ParseInt("pdfSkimReverseSearchPollMs", 300); // <= 0 disables reverse search
+}
+
+PDFBridgeSkim::~PDFBridgeSkim() {
+	stopPolling();
+}
+
+void PDFBridgeSkim::OpenDocument(const PDFFile &pdfFile) {
+	stopPolling(); // stop any poll bound to a previous document before rebinding pdfPath
+
+	auto path = pdfFile.getPath();
+
+	if (!filesystem::exists(path)) { // PDF file does not exist, do not attempt to load
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: PDF file does not exist");
+		return;
+	}
+
+	pdfPath = filesystem::canonical(path).string();
+
+	SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim OpenDocument: %s", pdfPath.c_str());
+
+	// Empty body: just ensure the document is open in Skim.
+	runAppleScript(scriptForDocument(appName, pdfPath, @""));
+
+	startPolling(); // begin watching Skim's selection for reverse search
+}
+
+void PDFBridgeSkim::CloseDocument() {
+	stopPolling(); // joins the poll thread before we touch pdfPath/selection
+
+	// Leave the document open in Skim (the Evince backend likewise does not force-close);
+	// just drop our reference so a later search reports "no document" rather than acting on
+	// a stale one.
+	pdfPath.clear();
+
+	std::lock_guard<std::mutex> lock(selectionMutex);
+	currentSelection.clear();
+	selectionChanged = false;
+}
+
+void PDFBridgeSkim::DocumentSearch(const std::string &str, bool wholeWordsOnly, bool caseSensitive) {
+	if (pdfPath.empty()) {
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "PDFBridgeSkim: search attempted without any document open");
+		return;
+	}
+
+	if (wholeWordsOnly) {
+		// Skim's AppleScript 'find' verb has no whole-words option, so this searches as a
+		// substring regardless. Noted rather than silently misbehaving.
+		SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+		             "PDFBridgeSkim: whole-words-only is unsupported by Skim, searching as substring");
+	}
+
+	SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "PDFBridgeSkim DocumentSearch: %s", str.c_str());
+
+	NSString *body = [NSString stringWithFormat:
+		@"\tset sel to find theDoc text \"%@\" case sensitive search %@\n"
+		 "\tif sel is not missing value then\n"
+		 "\t\tset selection of theDoc to sel\n"
+		 "\t\tgo theDoc to sel\n"
+		 "\tend if",
+		toNSString(escapeForAppleScript(str)),
+		caseSensitive ? @"true" : @"false"];
+	runAppleScript(scriptForDocument(appName, pdfPath, body));
+}
+
+bool PDFBridgeSkim::HasNewSelection() {
+	// Called every frame from the render loop: only compare the cached value, never block.
+	std::lock_guard<std::mutex> lock(selectionMutex);
+	bool changed = selectionChanged;
+	selectionChanged = false;
+	return changed;
+}
+
+std::string PDFBridgeSkim::GetSelection() const {
+	std::lock_guard<std::mutex> lock(selectionMutex);
+	return currentSelection;
+}
+
+void PDFBridgeSkim::startPolling() {
+	if (pollIntervalMs <= 0) // reverse search disabled by config
+		return;
+	if (pollRunning.exchange(true)) // already running
+		return;
+	pollThread = std::thread(&PDFBridgeSkim::pollLoop, this);
+}
+
+void PDFBridgeSkim::stopPolling() {
+	if (!pollRunning.exchange(false))
+		return;
+	if (pollThread.joinable())
+		pollThread.join();
+}
+
+void PDFBridgeSkim::pollLoop() {
+	NSString *query = selectionQueryScript(appName, pdfPath);
+
+	while (pollRunning) {
+		std::string sel = runOsascript(query);
+
+		bool changed = false;
+		{
+			std::lock_guard<std::mutex> lock(selectionMutex);
+			if (sel != currentSelection) {
+				currentSelection = sel;
+				selectionChanged = true;
+				changed = true;
+			}
+		}
+
+		if (changed) {
+			// OBV's render loop skips app.Update() (and thus HandlePDFBridgeSelection) once it
+			// has been idle for a while, so a background selection change would not be acted on
+			// until the next input event. Push an event to wake the loop and process it promptly.
+			SDL_Event ev;
+			SDL_zero(ev);
+			ev.type = SDL_USEREVENT;
+			SDL_PushEvent(&ev);
+		}
+
+		// Sleep in small slices so stopPolling() stays responsive.
+		for (int slept = 0; slept < pollIntervalMs && pollRunning; slept += 50)
+			std::this_thread::sleep_for(std::chrono::milliseconds(std::min(50, pollIntervalMs - slept)));
+	}
+}
+
+#endif // ENABLE_PDFBRIDGE_SKIM


### PR DESCRIPTION
Fixes #285.

## What this does

Today the PDF search button does nothing on macOS: the `#ifdef` chain in `BoardView.h` has no macOS branch, so it falls through to the base `PDFBridge` — whose methods are all empty no-ops. The click calls into nothing and returns. It's an unimplemented backend, not a bug.

This adds `PDFBridgeSkim`, a backend that drives [Skim](https://skim-app.sourceforge.io/) over AppleScript — the same "drive an existing viewer" model as the Evince (Linux) and SumatraPDF (Windows) backends. Both directions of cross-probing work:

- **Forward** (board → schematic): clicking a part's *PDF Search* jumps Skim to that designator and highlights it.
- **Reverse** (schematic → board): selecting text in Skim highlights the matching part on the board.

## Why Skim

It's open-source, actively maintained, and scriptable out of the box — `find`, `selection`, `go`, `obtain` cover everything the bridge needs, so there's nothing to patch. That's the same reasoning behind picking Evince and SumatraPDF for the other platforms.

## How it works

- **Forward search / open** run synchronously via `NSAppleScript` on the render thread — they only fire on a button press, so a brief round-trip is fine.
- **The document is resolved by path and opened on demand** on every operation, so a search still works if the user has closed the Skim window or has other PDFs open (no reliance on `document 1`).
- **Reverse search polls** Skim's selection on a background thread — Skim has no cross-process selection-change signal, so polling is the option. It runs off the render loop and writes to a mutex-guarded value that `HasNewSelection()` only compares, never blocking. Interval is configurable via `pdfSkimReverseSearchPollMs` (default 300 ms; `0` disables reverse search). The poll uses an `osascript` subprocess because `NSAppleScript` is main-thread affine.
- **The poll wakes the render loop** with `SDL_PushEvent` when the selection changes — OBV skips `Update()` after it's been idle a while, so without the nudge a background selection wouldn't be picked up until the next input event.
- **`NSAppleEventsUsageDescription`** is added to the bundle Info.plist — without it the automation events fail silently (which reproduces the exact "button does nothing" symptom).
- Skim's `find` has no whole-words option, so `wholeWordsOnly` searches as a substring — logged at debug rather than silently ignored.

Everything macOS-specific is guarded by `ENABLE_PDFBRIDGE_SKIM` (defined in the `if(APPLE)` CMake branch) or `if(APPLE)`, so the Linux and Windows builds are untouched. `PDFBridgeSkim.mm` is compiled with ARC; the rest of the ObjC++ stays manual retain/release.

## Commits

1. `fix(PDFBridge): warn when no PDF bridge backend is available on this platform` — surfaces the silent failure on any platform without a backend, instead of the click doing nothing.
2. `feat(PDFBridge): add macOS Skim backend for boardview-schematic cross-probing` — the backend, CMake wiring, `BoardView.h` dispatch branch, and the Info.plist entitlement.

## Testing

Built and tested on an M4 Pro, macOS 26.5.2, Skim 1.7.15, against a real board + matching schematic PDF. Forward search jumps Skim to the clicked part; reverse search highlights the board part from a Skim text selection, hands-free. Built arm64; I don't have an Intel Mac to verify the x86_64 half of a universal build, but nothing here is arch-specific.

Happy to adjust the approach — polling cadence, config keys, whatever — if you'd rather it work differently.
