### PR TITLE
Fix build with MSVC

### DIFF
--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 if(WIN32)
 	add_definitions(-DUNICODE)
 	add_definitions(-D_UNICODE)
+	# windows.h defines min/max macros which break std::min/std::max
+	add_definitions(-DNOMINMAX)
 else()
 	if(APPLE)
 		find_library(COCOA_LIBRARY Cocoa)

--- a/src/openboardview/FileFormats/FZFile.cpp
+++ b/src/openboardview/FileFormats/FZFile.cpp
@@ -385,7 +385,7 @@ void FZFile::parse(std::vector<char> &buf, const std::array<uint32_t, 44> &fzkey
 				char *name = READ_STR();
 
 				// use name field as pin name if snum is empty string or "0" (decimal zero as string)
-				bool name_is_pin_position_id = strlen(pin.snum) <= 1 && (pin.snum[0] == '\0' or pin.snum[0] == '0');
+				bool name_is_pin_position_id = strlen(pin.snum) <= 1 && (pin.snum[0] == '\0' || pin.snum[0] == '0');
 				if (name_is_pin_position_id)
 				{
 					pin.name = name;

--- a/src/openboardview/utils.h
+++ b/src/openboardview/utils.h
@@ -7,6 +7,11 @@
 
 #include "filesystem_impl.h"
 
+// MSVC does not provide __PRETTY_FUNCTION__; __FUNCSIG__ is the equivalent
+#if defined(_MSC_VER) && !defined(__PRETTY_FUNCTION__)
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
+
 // Verify predicate X, if false write error to ERROR_MSG and log and execute ACTION
 #define ENSURE_OR_FAIL(X, ERROR_MSG, ACTION) if (!(X)) { \
 		ERROR_MSG = std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " + __PRETTY_FUNCTION__ + ": Assertion `" + #X + "' failed."; \


### PR DESCRIPTION
## What this does

Three independent, pre-existing MSVC build breaks — not tied to any one
feature, just code that had only ever been compiled with GCC/Clang.

## How it works

- `FZFile.cpp`: `or` used in place of `||` — a GCC/Clang extension
  keyword MSVC's standard-conformance mode rejects outright.
- `utils.h`: `__PRETTY_FUNCTION__` is GCC/Clang-only; `#if defined(_MSC_VER)`
  now maps it to MSVC's `__FUNCSIG__`.
- `CMakeLists.txt`: `windows.h` defines `min`/`max` macros that shadow
  `std::min`/`std::max` wherever it's included transitively; `NOMINMAX`
  suppresses them.

all three are Windows/MSVC Guard

## Testing

Built clean with MSVC (Visual Studio 18, `/std:c++14`) after this change;
previously failed on all three points above.