### PR TITLE
Add support for Tebo-ICT View (.tvw) board files

### DIFF
--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -28,6 +28,7 @@
 #include "FileFormats/CSTFile.h"
 #include "FileFormats/FZFile.h"
 #include "FileFormats/GenCADFile.h"
+#include "FileFormats/TVWFile.h"
 #include "FileFormats/XZZPCBFile.h"
 #include "GUI/DPI.h"
 #include "GUI/Fonts.h"
@@ -140,6 +141,8 @@ int BoardView::LoadFile(const filesystem::path &filepath) {
 				m_file = new BRDAllegroFile(buffer);
 			else if (XZZPCBFile::verifyFormat(buffer))
 				m_file = new XZZPCBFile(buffer, config.XZZPCBKey);
+			else if (TVWFile::verifyFormat(buffer))
+				m_file = new TVWFile(buffer);
 			else
 				m_error_msg = "Unrecognized file format.";
 

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -82,6 +82,8 @@ set(SOURCES
 	FileFormats/CSTFile.cpp
 	FileFormats/FZFile.cpp
 	FileFormats/GenCADFile.cpp
+	FileFormats/TVWFile.cpp
+	FileFormats/tebo/TeboBoard.cpp
 	FileFormats/XZZPCBFile.cpp
 	NetList.cpp
 	PartList.cpp

--- a/src/openboardview/FileFormats/TVWFile.cpp
+++ b/src/openboardview/FileFormats/TVWFile.cpp
@@ -1,0 +1,167 @@
+#include "TVWFile.h"
+
+#include "tebo/TeboBoard.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <sstream>
+
+// Every .tvw begins with a length-prefixed, char-ciphered type string that
+// decodes to "Tebo-ictview files." — the raw bytes are a stable signature.
+bool TVWFile::verifyFormat(std::vector<char> &buf) {
+	static const char sig[] = {0x13, 'O', '9', '5', 'w', '-', '2', '8', 'p', 's',
+	                           '4', '9', 'm', ' ', '0', '2', 'v', '9', 'o', '.'};
+	if (buf.size() < sizeof(sig)) return false;
+	return std::equal(std::begin(sig), std::end(sig), buf.begin());
+}
+
+const char *TVWFile::intern(const std::string &s) {
+	pool_.push_back(s);
+	return pool_.back().c_str();
+}
+
+namespace {
+// Tebo coordinates are 2-decimal fixed point; convert to integer mil like the
+// reference Toptest exporter (Fixed32 -> int via float, i.e. raw/100).
+inline BRDPoint ToPoint(Tebo::Vector2S v) {
+	return BRDPoint(static_cast<int>(static_cast<float>(v.X)),
+	                static_cast<int>(static_cast<float>(v.Y)));
+}
+} // namespace
+
+TVWFile::TVWFile(std::vector<char> &buf) {
+	try {
+		std::string data(buf.begin(), buf.end());
+		std::istringstream is(data, std::ios::in | std::ios::binary);
+
+		Tebo::Board board;
+		board.Read(is);
+
+		// Locate the top and bottom copper (logic) layers; parts/pins live there.
+		int topIdx = -1, botIdx = -1;
+		for (size_t i = 0; i < board.Layers.size(); i++) {
+			auto *lo = dynamic_cast<Tebo::LogicLayer *>(board.Layers[i].get());
+			if (!lo) continue;
+			if (lo->Type == Tebo::LayerType::Top) topIdx = static_cast<int>(i);
+			else if (lo->Type == Tebo::LayerType::Bottom) botIdx = static_cast<int>(i);
+		}
+
+		// Real board outline: the route ("Roul"/OUTLINE) layer stores the board
+		// edge as milled slots. Collect them now, sanity-filter against the pin
+		// extents once those are known (some files contain stray segments), and
+		// fall back to a bounding box if nothing usable survives.
+		std::vector<std::pair<BRDPoint, BRDPoint>> rawOutline;
+		for (auto const &lp : board.Layers) {
+			auto *tl = dynamic_cast<Tebo::ThroughLayer *>(lp.get());
+			if (!tl || tl->Type != Tebo::LayerType::Roul) continue;
+			for (auto const &slot : tl->DrillSlots)
+				rawOutline.emplace_back(ToPoint(slot.Begin), ToPoint(slot.End));
+		}
+
+		// Intern net names once so pins can share the pointers.
+		std::vector<const char *> netPtr(board.Nets.size(), nullptr);
+		for (size_t i = 0; i < board.Nets.size(); i++)
+			netPtr[i] = intern(board.Nets[i]);
+
+		auto layerOf = [&](uint32_t partLayer) -> Tebo::LogicLayer * {
+			int idx = -1;
+			if (static_cast<int>(partLayer) == topIdx) idx = topIdx;
+			else if (static_cast<int>(partLayer) == botIdx) idx = botIdx;
+			if (idx < 0) return nullptr;
+			return dynamic_cast<Tebo::LogicLayer *>(board.Layers[idx].get());
+		};
+
+		BRDPoint bmin{INT32_MAX, INT32_MAX}, bmax{INT32_MIN, INT32_MIN};
+
+		for (Tebo::Part const &part : board.Parts) {
+			Tebo::LogicLayer *layer = layerOf(part.Layer);
+			if (!layer) continue; // not on top/bottom copper
+			bool top = static_cast<int>(part.Layer) == topIdx;
+
+			BRDPart bp;
+			bp.name          = intern(part.Name);
+			bp.part_type     = BRDPartType::SMD; // refined below if a pad has a hole
+			bp.mounting_side = top ? BRDPartMountingSide::Top : BRDPartMountingSide::Bottom;
+			bp.p1            = ToPoint(part.Bbox.Min);
+			bp.p2            = ToPoint(part.Bbox.Max);
+			// Component value / manufacturer part number, e.g. "15P_50V_J_NPO_0201" or
+			// "MC74VHC1G32DFT2G_SC70-5". OBV shows this next to the part and searches it.
+			if (!part.Value.empty())
+				bp.mfgcode = part.Value;
+			else if (!part.Desc.empty())
+				bp.mfgcode = part.Desc;
+
+			unsigned int const partIndex = static_cast<unsigned int>(parts.size()) + 1;
+			for (Tebo::Pin const &pin : part.Pins) {
+				BRDPin bpin;
+				bpin.part = partIndex;
+				bpin.side = top ? BRDPinSide::Top : BRDPinSide::Bottom;
+				bpin.snum = intern(pin.Name);
+				bpin.name = bpin.snum;
+
+				uint32_t const padIdx = pin.Handle / 8;
+				if (padIdx < layer->Pads.size()) {
+					Tebo::Pad const &pad = layer->Pads[padIdx];
+					bpin.pos = ToPoint(pad.Pos);
+					if (pad.Net >= 0 && static_cast<size_t>(pad.Net) < netPtr.size())
+						bpin.net = netPtr[pad.Net];
+					else
+						bpin.net = "UNCONNECTED";
+					// through-hole pads mark the whole part as TH
+					if (pad.HasHole) bp.part_type = BRDPartType::ThroughHole;
+					// draw the pad at its real size instead of a default dot
+					if (pad.Shape) {
+						float const sx = static_cast<float>(pad.Shape->Size.X);
+						float const sy = static_cast<float>(pad.Shape->Size.Y);
+						float const d  = (sx > 0.0f && sy > 0.0f) ? std::min(sx, sy) : std::max(sx, sy);
+						if (d > 0.0f) bpin.radius = d / 2.0;
+					}
+				} else {
+					bpin.pos = ToPoint(part.Pos);
+					bpin.net = "UNCONNECTED";
+				}
+				bmin.x = std::min(bmin.x, bpin.pos.x);
+				bmin.y = std::min(bmin.y, bpin.pos.y);
+				bmax.x = std::max(bmax.x, bpin.pos.x);
+				bmax.y = std::max(bmax.y, bpin.pos.y);
+				pins.push_back(bpin);
+			}
+			bp.end_of_pins = static_cast<unsigned int>(pins.size());
+			parts.push_back(bp);
+		}
+
+		// Keep only outline segments that sit near the populated board area: a
+		// few files carry stray slots whose coordinates are wildly out of range
+		// and would blow the board extents up to thousands of inches.
+		if (!rawOutline.empty() && bmin.x <= bmax.x) {
+			int const mx = std::max(2000, (bmax.x - bmin.x) / 2);
+			int const my = std::max(2000, (bmax.y - bmin.y) / 2);
+			auto inRange = [&](const BRDPoint &p) {
+				return p.x >= bmin.x - mx && p.x <= bmax.x + mx && p.y >= bmin.y - my && p.y <= bmax.y + my;
+			};
+			for (auto const &s : rawOutline) {
+				if (inRange(s.first) && inRange(s.second)) outline_segments.push_back(s);
+			}
+		}
+
+		// Fallback outline: rectangle around all pins, only when the file had no
+		// route layer to give us the real board edge.
+		if (outline_segments.size() < 3 && bmin.x <= bmax.x) {
+			format.push_back({bmin.x, bmin.y});
+			format.push_back({bmax.x, bmin.y});
+			format.push_back({bmax.x, bmax.y});
+			format.push_back({bmin.x, bmax.y});
+			format.push_back({bmin.x, bmin.y});
+		}
+
+		num_parts  = static_cast<unsigned int>(parts.size());
+		num_pins   = static_cast<unsigned int>(pins.size());
+		num_nails  = static_cast<unsigned int>(nails.size());
+		num_format = static_cast<unsigned int>(format.size());
+		valid      = num_parts > 0;
+		if (!valid) error_msg = "TVW: no parts found on top/bottom layers";
+	} catch (const std::exception &e) {
+		valid     = false;
+		error_msg = std::string("TVW parse error: ") + e.what();
+	}
+}

--- a/src/openboardview/FileFormats/TVWFile.h
+++ b/src/openboardview/FileFormats/TVWFile.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "BRDFileBase.h"
+
+#include <deque>
+#include <string>
+#include <vector>
+
+// Tebo-ICT View (*.TVW) board files.
+//
+// The binary .tvw format was reverse-engineered by Pavel Kovalenko
+// (github.com/nitrocaster/eagleview, MIT). The actual container parser lives
+// in FileFormats/tebo/ (Tebo::Board); this class adapts the parsed result to
+// OpenBoardView's BRDFileBase model.
+class TVWFile : public BRDFileBase {
+  public:
+	TVWFile(std::vector<char> &buf);
+
+	static bool verifyFormat(std::vector<char> &buf);
+
+  private:
+	// stable backing storage for the const char* names/nets handed to BRDFileBase
+	std::deque<std::string> pool_;
+	const char *intern(const std::string &s);
+};

--- a/src/openboardview/FileFormats/tebo/Box2.hpp
+++ b/src/openboardview/FileFormats/tebo/Box2.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "Common.hpp" // CONSTEXPR_DEF
+#include <cstdint> // int32_t
 #include <algorithm> // std::min, std::max
 #include <limits> // std::numeric_limits
 

--- a/src/openboardview/FileFormats/tebo/Box2.hpp
+++ b/src/openboardview/FileFormats/tebo/Box2.hpp
@@ -1,0 +1,140 @@
+/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2019 Pavel Kovalenko
+ */
+
+#pragma once
+
+#include <algorithm> // std::min, std::max
+#include <limits> // std::numeric_limits
+
+template <typename T>
+struct Vector2T;
+
+template <typename S>
+struct Box2T
+{
+    using Scalar = S;
+    using Vec2 = Vector2T<Scalar>;
+    using Box2 = Box2T<Scalar>;
+
+    Vec2 Min, Max;
+
+    Box2T() = default;
+
+    constexpr Box2T(Vec2 size) :
+        Min(size/2),
+        Max(-size/2)
+    {}
+
+    constexpr Box2T(Vec2 min, Vec2 max) :
+        Min(min),
+        Max(max)
+    {}
+
+    constexpr Box2T(Vec2 center, Scalar radius) :
+        Min(center - Vec2(radius, radius)),
+        Max(center + Vec2(radius, radius))
+    {}
+
+    constexpr Scalar Width() const
+    { return Max.X-Min.X; }
+
+    constexpr Scalar Height() const
+    { return Max.Y-Min.Y; }
+
+    constexpr Vec2 Center() const
+    { return Min + (Max-Min)/2; }
+
+    constexpr Vec2 Size() const
+    { return Vec2(Width(), Height()); }
+
+    constexpr bool Contains(Vec2 v) const
+    { return Min.X<=v.X && v.X<=Max.X && Min.Y<=v.Y && v.Y<=Max.Y; }
+
+    bool Contains(Scalar x, Scalar y) const
+    { return Contains({x, y}); }
+
+    bool Contains(Box2T const &b) const
+    { return Contains(b.Min) && Contains(b.Max); }
+
+    Box2T &Merge(Vec2 p)
+    {
+        Min = {std::min(Min.X, p.X), std::min(Min.Y, p.Y)};
+        Max = {std::max(Max.X, p.X), std::max(Max.Y, p.Y)};
+        return *this;
+    }
+
+    Box2T &Merge(Box2T const &b)
+    {
+        Merge(b.Min);
+        Merge(b.Max);
+        return *this;
+    }
+
+    Box2T &Shrink(Scalar s)
+    {
+        Min += s;
+        Max -= s;
+        return *this;
+    }
+
+    Box2T &Grow(Scalar s)
+    {
+        Min -= s;
+        Max += s;
+        return *this;
+    }
+
+    bool operator==(Box2T const &rhs) const
+    { return Min==rhs.Min && Max==rhs.Max; }
+    
+    bool operator!=(Box2T const &rhs) const
+    { return Min!=rhs.Min || Max!=rhs.Max; }
+
+    bool IsEmpty() const
+    { return Min.X>Max.X || Min.Y>Max.Y; }
+
+    Box2T &operator+=(Vec2 offset)
+    {
+        Min += offset;
+        Max += offset;
+        return *this;
+    }
+
+    Box2T &operator-=(Vec2 offset)
+    {
+        Min -= offset;
+        Max -= offset;
+        return *this;
+    }
+
+    Box2T operator+(Vec2 offset) const
+    { return {Min+offset, Max+offset}; }
+
+    Box2T operator-(Vec2 offset) const
+    { return {Min-offset, Max-offset}; }
+
+    template <typename T>
+    operator Box2T<T>() const { return {Vector2T<T>(Min), Vector2T<T>(Max)}; }
+
+private:
+    using Limits = std::numeric_limits<Scalar>;
+
+public:
+    static constexpr Scalar ScalarEps{Limits::epsilon()};
+    static const Box2T Empty;
+};
+
+using Box2 = Box2T<float>;
+using Box2f = Box2T<float>;
+using Box2d = Box2T<double>;
+using Box2i = Box2T<int32_t>;
+
+template <typename Scalar>
+CONSTEXPR_DEF Box2T<Scalar> Box2T<Scalar>::Empty
+    {Vector2T<Scalar>::MaxValue, Vector2T<Scalar>::MinValue};

--- a/src/openboardview/FileFormats/tebo/Common.hpp
+++ b/src/openboardview/FileFormats/tebo/Common.hpp
@@ -1,0 +1,60 @@
+/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2020 Pavel Kovalenko
+ *
+ * Adapted for OpenBoardView: assertions throw instead of trapping, so a
+ * malformed .tvw fails gracefully rather than crashing the application.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+#if defined(_MSC_VER)
+#define FUNCTION_NAME __FUNCTION__
+// workaround for MSVC bug
+#define CONSTEXPR_DEF const
+#elif defined(__GNUC__)
+#define FUNCTION_NAME __PRETTY_FUNCTION__
+#define CONSTEXPR_DEF constexpr
+#else
+#define FUNCTION_NAME "?"
+#define CONSTEXPR_DEF constexpr
+#endif
+
+// Verbose parse tracing (off by default; the parser is a library inside OBV).
+#if !defined(TEBO_VERBOSE)
+#define TEBO_VERBOSE 0
+#endif
+#if TEBO_VERBOSE
+#define TEBO_LOG(...) std::printf(__VA_ARGS__)
+#else
+#define TEBO_LOG(...) ((void)0)
+#endif
+
+[[noreturn]] inline void Fail(char const *expr, char const *func,
+    char const *file, int line, char const *desc)
+{
+    // report only the basename: full build paths are noise for the user
+    char const *base = file;
+    for (char const *p = file; *p; p++)
+        if (*p == '/' || *p == '\\') base = p + 1;
+    (void)func;
+    char buf[512];
+    std::snprintf(buf, sizeof(buf), "%s (%s) at %s:%d", desc, expr, base, line);
+    throw std::runtime_error(buf);
+}
+
+#define R_ASSERT(expr) \
+    do \
+    { \
+        if (!(expr)) \
+            Fail(#expr, FUNCTION_NAME, __FILE__, __LINE__, "assertion failed"); \
+    } while (0)

--- a/src/openboardview/FileFormats/tebo/Fixed32.hpp
+++ b/src/openboardview/FileFormats/tebo/Fixed32.hpp
@@ -1,0 +1,78 @@
+/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2019 Pavel Kovalenko
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "Vector2.hpp"
+
+namespace Tebo
+{
+    template <size_t DecimalPlaces = 2>
+    class Fixed32T
+    {
+    private:
+        static constexpr int32_t Pow(int32_t base, size_t power)
+        {
+            if (!power)
+                return 1;
+            return base*Pow(base, power-1);
+        }
+
+        static constexpr int32_t decimalMultiplier = Pow(10, DecimalPlaces);
+        int32_t value;
+
+    public:
+        Fixed32T() { value = 0; }
+        Fixed32T(int32_t a) { value = a; }
+
+        operator bool() const
+        { return !!value; }
+        int32_t ToRawInt() const
+        { return value; }
+        int32_t Int() const
+        { return value / decimalMultiplier; }
+        int32_t Frac() const
+        { return std::abs(value) % decimalMultiplier; }
+        operator float() const
+        { return value*1.0f / decimalMultiplier; }
+        Fixed32T operator+(Fixed32T rhs) const
+        { return Fixed32T(value + rhs.value); }
+        Fixed32T operator-(Fixed32T rhs) const
+        { return Fixed32T(value - rhs.value); }
+        bool operator<(Fixed32T rhs) const
+        { return value < rhs.value; }
+        bool operator>(Fixed32T rhs) const
+        { return value > rhs.value; }
+        bool operator<=(Fixed32T rhs) const
+        { return value <= rhs.value; }
+        bool operator>=(Fixed32T rhs) const
+        { return value >= rhs.value; }
+        bool operator==(Fixed32T rhs) const
+        { return value == rhs.value; }
+        bool operator!=(Fixed32T rhs) const
+        { return value != rhs.value; }
+    };
+
+    using Fixed32 = Fixed32T<2>;
+
+    struct Vector2S
+    {
+        Fixed32 X, Y;
+
+        template <typename T>
+        operator Vector2T<T>() const
+        { return {X, Y}; }
+
+        bool operator==(Vector2S rhs) const
+        { return X == rhs.X && Y == rhs.Y; }
+        bool operator!=(Vector2S rhs) const
+        { return X != rhs.X || Y != rhs.Y; }
+    };
+} // namespace Tebo

--- a/src/openboardview/FileFormats/tebo/Fixed32.hpp
+++ b/src/openboardview/FileFormats/tebo/Fixed32.hpp
@@ -18,12 +18,9 @@ namespace Tebo
     class Fixed32T
     {
     private:
+        // single return: a C++11 constexpr body cannot hold statements
         static constexpr int32_t Pow(int32_t base, size_t power)
-        {
-            if (!power)
-                return 1;
-            return base*Pow(base, power-1);
-        }
+        { return power ? base*Pow(base, power-1) : 1; }
 
         static constexpr int32_t decimalMultiplier = Pow(10, DecimalPlaces);
         int32_t value;

--- a/src/openboardview/FileFormats/tebo/StreamReader.hpp
+++ b/src/openboardview/FileFormats/tebo/StreamReader.hpp
@@ -1,0 +1,105 @@
+/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2019 Pavel Kovalenko
+ */
+
+#pragma once
+
+#include "Common.hpp"
+#include "Fixed32.hpp"
+#include <istream>
+
+namespace Tebo
+{
+    class StreamReader
+    {
+    protected:
+        std::istream &is;
+        std::streampos rPos;
+
+    public:
+        StreamReader(std::istream &s) : is(s)
+        {
+            rPos = Tell();
+        }
+
+        std::streampos Tell() { return is.tellg(); }
+        void Seek(size_t pos) { is.seekg(pos); }
+
+        uint8_t ReadU8()
+        {
+            uint8_t r;
+            is.read((char *)&r, 1);
+            rPos = Tell();
+            return r;
+        }
+
+        bool ReadBool8()
+        {
+            uint8_t const v = ReadU8();
+            R_ASSERT(v <= 1);
+            return v;
+        }
+
+        template <typename T>
+        void Read(T *dst, size_t count)
+        {
+            std::streamsize const itemSize = sizeof(T);
+            is.read((char *)dst, itemSize*count);
+            rPos = Tell();
+        }
+
+        uint16_t ReadU16()
+        {
+            uint16_t r;
+            Read(&r, 1);
+            return r;
+        }
+
+        uint32_t ReadU32()
+        {
+            uint32_t r;
+            Read(&r, 1);
+            return r;
+        }
+
+        int32_t ReadS32()
+        {
+            int32_t r;
+            Read(&r, 1);
+            return r;
+        }
+
+        float ReadFloat()
+        {
+            float r;
+            Read(&r, 1);
+            return r;
+        }
+
+        Vector2S ReadVec2S()
+        { return {ReadS32(), ReadS32()}; }
+
+        std::string ReadString255()
+        {
+            uint8_t const size = ReadU8();
+            std::string s;
+            s.resize(size);
+            Read(s.data(), size);
+            return s;
+        }
+    };
+
+    // inline: this header is included from multiple translation units
+    template <>
+    inline void StreamReader::Read(bool *dst, size_t count)
+    {
+        for (size_t i = 0; i < count; i++)
+            dst[i] = ReadBool8();
+    }
+
+} // namespace Tebo

--- a/src/openboardview/FileFormats/tebo/TeboBoard.cpp
+++ b/src/openboardview/FileFormats/tebo/TeboBoard.cpp
@@ -1,0 +1,997 @@
+/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2020 Pavel Kovalenko
+ */
+
+#include "TeboBoard.hpp"
+
+namespace Tebo
+{
+    std::unique_ptr<Shape> Shape::Load(StreamReader &r)
+    {
+        {
+            uint32_t one = r.ReadU32();
+            (void)one;
+            R_ASSERT(one == 1);
+        }
+        auto const size = r.ReadVec2S();
+        auto const type = ShapeType(r.ReadU32());
+        switch (type)
+        {
+        case ShapeType::Round:
+        {
+            auto const skip = r.ReadVec2S();
+            (void)skip;
+            return std::make_unique<Round>(size);
+        }
+        case ShapeType::Rect:
+        {
+            auto const turn = r.ReadFloat();
+            auto const skip = r.ReadS32();
+            (void)skip;
+            return std::make_unique<Rect>(size, turn);
+        }
+        case ShapeType::Poly:
+        {
+            auto const skip = r.ReadU32();
+            (void)skip;
+            auto const name = r.ReadString255();
+            auto shape = std::make_unique<Poly>(size, name);
+            shape->BBox.Min = r.ReadVec2S();
+            shape->BBox.Max = r.ReadVec2S();
+            auto subObjCount = r.ReadU32();
+            for (uint32_t i = 0; i < subObjCount; i++)
+            {
+                auto const subObjType = r.ReadU32();
+                switch (subObjType)
+                {
+                case 2: // poly
+                {
+                    R_ASSERT(shape->Vertices.empty());
+                    r.Read(shape->Flags, 3);
+                    uint32_t const vertexCount = r.ReadU32();
+                    shape->Vertices.reserve(vertexCount);
+                    for (uint32_t i = 0; i < vertexCount; i++)
+                        shape->Vertices.push_back(r.ReadVec2S());
+                    break;
+                }
+                case 5: // line
+                {
+                    shape->Lines.emplace_back();
+                    shape->Lines.back().Load(r);
+                    break;
+                }
+                default:
+                    R_ASSERT(!"Unrecognized subobject type");
+                    break;
+                }
+            }
+            return shape;
+        }
+        case ShapeType::RoundRect:
+        {
+            auto const turn = r.ReadFloat();
+            auto const cornerRadius = r.ReadS32();
+            return std::make_unique<RoundRect>(size, cornerRadius, turn);
+        }
+        default:
+            R_ASSERT(!"Unrecognized shape type");
+            return nullptr;
+        }
+    }
+
+    void Poly::Line::Load(StreamReader &r)
+    {
+        Param1 = r.ReadU32();
+        R_ASSERT(Param1 == 1);
+        Param2 = r.ReadU32();
+        R_ASSERT(Param2 == 0);
+        Param3 = r.ReadU32();
+        R_ASSERT(Param3 == 0);
+        Start = r.ReadVec2S();
+        End = r.ReadVec2S();
+        Width = r.ReadS32();
+    }
+
+    static void DecodeString(std::string &s)
+    {
+        for (size_t i = 0; i < s.size(); i++)
+        {
+            char c = s[i];
+            if ('a' <= c && c <= 'j')
+            {
+                char x = c - i%3 - 4;
+                if (x < 'a')
+                    x += 10;
+                s[i] = 154 - x;
+                continue;
+            }
+            if ('k' <= c && c <= 'z')
+            {
+                char x = c - i%10 - 5;
+                c = x;
+                if (x < 'k')
+                    c = x + 16;
+                s[i] = c;
+                continue;
+            }
+            if ('A' <= c && c <= 'Z')
+            {
+                char x = c + i%10 + 5;
+                c = x;
+                if (x > 'Z')
+                    c = x - 26;
+                s[i] = c;
+                continue;
+            }
+            if ('0' <= c && c <= '9')
+            {
+                char x = c + i%3 + 4;
+                if (x > '9')
+                    x -= 10;
+                s[i] = x + 49;
+                continue;
+            }
+        }
+    }
+
+    void TvwHeader::Load(StreamReader &r)
+    {
+        Type = r.ReadString255();
+        DecodeString(Type);
+        Const1 = r.ReadU32();
+        Customer = r.ReadString255();
+        DecodeString(Customer);
+        Const2 = r.ReadU8();
+        Date = r.ReadString255();
+        DecodeString(Date);
+        r.Read(Const3, 3);
+        Size1 = r.ReadU32();
+        Size2 = r.ReadU32();
+        Size3 = r.ReadU32();
+        LayerCount = r.ReadU32();
+    }
+
+    ObjectType Object::Detect(StreamReader &r)
+    {
+        uint32_t const maxSkips = 4;
+        for (uint32_t i = 0; i < maxSkips; i++)
+        {
+            uint32_t const type = r.ReadU32();
+            if (!type)
+                continue;
+            return ObjectType(type);
+        }
+        return ObjectType::Undefined;
+    }
+
+    [[maybe_unused]] static char const *LayerTypeToString(LayerType type)
+    {
+        switch (type)
+        {
+        case LayerType::Document: return "Document";
+        case LayerType::Top: return "Top";
+        case LayerType::Bottom: return "Bottom";
+        case LayerType::Signal: return "Signal";
+        case LayerType::Plane: return "Plane";
+        case LayerType::SolderTop: return "SolderTop";
+        case LayerType::SolderBottom: return "SolderBottom";
+        case LayerType::SilkTop: return "SilkTop";
+        case LayerType::SilkBottom: return "SilkBottom";
+        case LayerType::PasteTop: return "PasteTop";
+        case LayerType::PasteBottom: return "PasteBottom";
+        case LayerType::Drill: return "Drill";
+        case LayerType::Roul: return "Roul";
+        default: return "unknown";
+        }
+    }
+
+    void Object::Load(StreamReader &r)
+    {
+        // 3, 2, 1 # logic layer
+        // 1, 2, 1 # thru layer (from 0 to 0)
+        uint32_t const pos(r.Tell());
+        (void)pos;
+        r.Read(Magic, 2);
+        R_ASSERT(Magic[0] == 2 && Magic[1] == 1);
+        Name = r.ReadString255();
+        InitialName = r.ReadString255();
+        InitialPath = r.ReadString255();
+        Type = LayerType(r.ReadU32());
+        PadColor = r.ReadU32();
+        LineColor = r.ReadU32();
+        TEBO_LOG("- loading object name[%s] type[%s] addr[0x%08X]\n",
+            Name.c_str(), LayerTypeToString(Type), pos);
+    }
+
+    void TestPoint::Load(StreamReader &r)
+    {
+        Flag1 = r.ReadBool8();
+        P1 = r.ReadS32();
+        Handle = r.ReadS32();
+        P2 = r.ReadS32();
+        P3 = r.ReadS32();
+        Pos = r.ReadVec2S();
+        ValidatePos(Pos);
+        P4 = r.ReadS32();
+        Flag2 = r.ReadBool8();
+        P5 = r.ReadS32();
+        P6 = r.ReadS32();
+        N = r.ReadS32();
+    }
+
+    void TestPoint2::Load(StreamReader &r)
+    {
+        P1 = r.ReadS32();
+        Handle = r.ReadS32();
+        P2 = r.ReadS32();
+        Pos = r.ReadVec2S();
+        ValidatePos(Pos);
+        Pos1 = r.ReadVec2S();
+        Pos2 = r.ReadVec2S();
+        Flag1 = r.ReadBool8();
+        Flag2 = r.ReadBool8();
+        Flag3 = r.ReadBool8();
+        Nail = r.ReadU32();
+        Param = r.ReadS32();
+        Flag4 = r.ReadBool8();
+        Flag5 = r.ReadBool8();
+        Flag6 = r.ReadBool8();
+        N = r.ReadS32();
+    }
+
+    void TestNode::Load(StreamReader &r)
+    {
+        Current = r.ReadU32();
+        Next = r.ReadU32();
+        Flag = r.ReadBool8();
+    }
+
+    void UnknownItem::Load(StreamReader &r)
+    {
+        Name = r.ReadString255();
+        Pos = r.ReadVec2S();
+        Z1 = r.ReadS32();
+        Param1 = r.ReadS32();
+        Param2 = r.ReadS32();
+        Param3 = r.ReadS32();
+        Z2 = r.ReadS32();
+        Z3 = r.ReadS32();
+        r.Read(Flags, 3);
+        Param4 = r.ReadS32();
+    }
+
+    void LogicLayer::LoadShapes(StreamReader &r)
+    {
+        // this is actually max dcode, not a 'count'
+        uint32_t shapeCount = r.ReadU32();
+        if (!shapeCount)
+            return;
+        R_ASSERT(shapeCount >= 10);
+        shapeCount -= 10;
+        for (uint32_t i = 0; i < shapeCount; i++)
+        {
+            std::unique_ptr<Shape> shape = Shape::Load(r);
+            R_ASSERT(shape != nullptr);
+            Shapes.push_back(std::move(shape));
+        }
+    }
+
+    void LogicLayer::LoadPads(StreamReader &r)
+    {
+        uint32_t const instanceCount = r.ReadU32();
+        if (!instanceCount)
+            return;
+        {
+            uint32_t const two = r.ReadU32();
+            (void)two;
+            R_ASSERT(two == 2);
+        }
+        Pads.reserve(instanceCount);
+        for (uint32_t i = 0; i < instanceCount; i++)
+        {
+            Pad obj;
+            obj.Net = r.ReadS32();
+            obj.DCode = r.ReadU32();
+            obj.Pos = r.ReadVec2S();
+            obj.IsExposed = r.ReadBool8();
+            obj.IsCopper = r.ReadBool8();
+            obj.TestpointParam = r.ReadU8();
+            R_ASSERT(obj.DCode-10 < Shapes.size());
+            obj.Shape = Shapes[obj.DCode-10].get();
+            if (obj.IsCopper)
+            {
+                obj.IsSomething = r.ReadBool8();
+                if (obj.TestpointParam == 1)
+                    r.Read(obj.TestPoint.Data12, 12);
+                if (obj.IsExposed || obj.IsSomething)
+                { // bbox of exposed area of this pad without rotation
+                    obj.Exposed.Min = r.ReadVec2S();
+                    obj.Exposed.Max = r.ReadVec2S();
+                }
+                obj.HasHole = r.ReadBool8();
+                obj.TailParam = r.ReadU8();
+                if (obj.HasHole)
+                {
+                    r.Read(obj.Hole.Data7, 7);
+                    obj.Hole.Size = r.ReadVec2S();
+                    obj.Hole.Param = r.ReadU8();
+                }
+            }
+            else // not copper
+            {
+                R_ASSERT(!obj.IsExposed && obj.TestpointParam != 1); // not expected
+                // no exposed copper => no extra data
+            }
+            Pads.push_back(std::move(obj));
+        }
+    }
+
+    void LogicLayer::LoadLines(StreamReader &r)
+    {
+        uint32_t const instanceCount = r.ReadU32();
+        if (!instanceCount)
+            return;
+        {
+            uint32_t const zero = r.ReadU32();
+            (void)zero;
+            R_ASSERT(!zero);
+        }
+        Lines.reserve(instanceCount);
+        for (uint32_t i = 0; i < instanceCount; i++)
+        {
+            Line obj;
+            obj.Net = r.ReadS32();
+            obj.DCode = r.ReadU32();
+            R_ASSERT(obj.DCode-10 < Shapes.size());
+            obj.StartPos = r.ReadVec2S();
+            obj.EndPos = r.ReadVec2S();
+            Lines.push_back(std::move(obj));
+        }
+    }
+
+    void LogicLayer::LoadArcs(StreamReader &r)
+    {
+        uint32_t const instanceCount = r.ReadU32();
+        if (!instanceCount)
+            return;
+        {
+            uint32_t zero = r.ReadU32();
+            (void)zero;
+            R_ASSERT(!zero);
+        }
+        Arcs.reserve(instanceCount);
+        for (uint32_t i = 0; i < instanceCount; i++)
+        {
+            Arc obj;
+            obj.Net = r.ReadS32();
+            obj.DCode = r.ReadU32();
+            R_ASSERT(obj.DCode-10 < Shapes.size());
+            obj.Pos = r.ReadVec2S();
+            obj.Radius = r.ReadS32();
+            obj.StartAngle = r.ReadFloat();
+            obj.SweepAngle = r.ReadFloat();
+            Arcs.push_back(std::move(obj));
+        }
+    }
+
+    void LogicLayer::LoadSurfaces(StreamReader &r)
+    {
+        uint32_t const instanceCount = r.ReadU32();
+        if (!instanceCount)
+            return;
+        {
+            uint32_t two = r.ReadU32();
+            (void)two;
+            R_ASSERT(two == 2);
+        }
+        Surfaces.reserve(instanceCount);
+        for (uint32_t i = 0; i < instanceCount; i++)
+        {
+            Surface obj;
+            obj.Net = r.ReadS32();
+            obj.EdgeCount = r.ReadU32();
+            obj.Vertices.reserve(obj.EdgeCount);
+            for (uint32_t vi = 0; vi < obj.EdgeCount; vi++)
+                obj.Vertices.push_back(r.ReadVec2S());
+            obj.LineWidth = r.ReadS32();
+            obj.VoidCount = r.ReadU32();
+            if (obj.VoidCount)
+            {
+                obj.Voids.reserve(obj.VoidCount);
+                for (uint32_t vi = 0; vi < obj.VoidCount; vi++)
+                {
+                    Cutout cutout;
+                    cutout.Tag = r.ReadU32();
+                    R_ASSERT(cutout.Tag <= 1);
+                    cutout.EdgeCount = r.ReadU32();
+                    cutout.Vertices.reserve(cutout.EdgeCount);
+                    for (uint32_t ci = 0; ci < cutout.EdgeCount; ci++)
+                        cutout.Vertices.push_back(r.ReadVec2S());
+                    obj.Voids.push_back(std::move(cutout));
+                }
+                obj.VoidFlags = r.ReadU32();
+            }
+            Surfaces.push_back(std::move(obj));
+        }
+    }
+
+    void LogicLayer::LoadUnknownItems(StreamReader &r)
+    {
+        UnknownItemCount = r.ReadU32();
+        UnknownItemsParam = r.ReadU32();
+        if (UnknownItemCount)
+        {
+            UnknownItems.reserve(UnknownItemCount);
+            for (uint32_t i = 0; i < UnknownItemCount; i++)
+            {
+                UnknownItems.emplace_back();
+                UnknownItems.back().Load(r);
+            }
+            uint32_t const skip = r.ReadU32();
+            (void)skip;
+            R_ASSERT(skip == 0);
+        }
+        uint32_t const skip = r.ReadU32();
+        (void)skip;
+        R_ASSERT(skip == 7);
+    }
+
+    void LogicLayer::LoadTestpoints(StreamReader &r)
+    {
+        TpCount = r.ReadU32();
+        TestPoints.reserve(TpCount);
+        for (uint32_t i = 0; i < TpCount; i++)
+        {
+            TestPoint obj;
+            obj.Load(r);
+            TestPoints.push_back(obj);
+        }
+        {
+            uint32_t skip = r.ReadU32();
+            (void)skip;
+            R_ASSERT(skip == 0);
+            skip = r.ReadU32();
+            R_ASSERT(skip == 4);
+        }
+        TPS2Size = r.ReadU32();
+        TPS2Param = r.ReadU32();
+        TestPoints2.reserve(TPS2Size);
+        for (uint32_t i = 0; i < TPS2Size; i++)
+        {
+            TestPoint2 obj;
+            obj.Load(r);
+            TestPoints2.push_back(obj);
+        }
+        TPS3Size = r.ReadU32();
+        TPS3Param = r.ReadU32();
+        TestPoints3.reserve(TPS3Size);
+        for (uint32_t i = 0; i < TPS3Size; i++)
+        {
+            TestPoint2 obj;
+            obj.Load(r);
+            TestPoints3.push_back(obj);
+        }
+        TestSequenceSize = r.ReadU32();
+        TestSequenceParam = r.ReadU32();
+        TestSequence.reserve(TestSequenceSize);
+        for (uint32_t i = 0; i < TestSequenceSize; i++)
+        {
+            TestNode obj;
+            obj.Load(r);
+            TestSequence.push_back(obj);
+        }
+        if (TestSequenceParam == 1)
+        {
+            uint32_t skip[3];
+            r.Read(skip, 3);
+            R_ASSERT(skip[0] == 0);
+            R_ASSERT(skip[1] == 0);
+            R_ASSERT(skip[2] == 0);
+        }
+    }
+
+    void LogicLayer::Load(StreamReader &r)
+    {
+        Object::Load(r);
+        LoadShapes(r);
+        if (!Shapes.empty())
+        {
+            bool extraData = false;
+            {
+                auto const skip1 = r.ReadU32();
+                (void)skip1;
+                // NOTE: this might be incorrect way to determine data order
+                // (maybe it has to be bound to layer type?)
+                switch (skip1)
+                {
+                default:
+                    R_ASSERT(!"Unrecognized data order");
+                    break;
+                case 1: // normal: shapes, [these flags], pads, lines, arcs, surfaces
+                    break;
+                case 2: // extra data: shapes, [these flags], pads, lines(0), arcs(0), surfaces, int32[4], lines, arcs
+                    extraData = true;
+                    break;
+                }
+                auto const skip2 = r.ReadU32();
+                R_ASSERT(skip2 == 0);
+                auto const skip3 = r.ReadU32();
+                R_ASSERT(skip3 == 1);
+            }
+            LoadPads(r);
+            LoadLines(r);
+            LoadArcs(r);
+            LoadSurfaces(r);
+            if (extraData)
+            {
+                uint32_t skip3[4];
+                r.Read(skip3, 4);
+                TEBO_LOG("* skip: %u, %u, %u, %u\n",
+                    skip3[0], skip3[1], skip3[2], skip3[3]);
+                // reload lines and arcs
+                LoadLines(r);
+                LoadArcs(r);
+                uint32_t const skip4 = r.ReadU32();
+                R_ASSERT(skip4 == 0);
+            }
+        }
+        LoadUnknownItems(r);
+        LoadTestpoints(r);
+    }
+
+    void ThroughLayer::Tool::Load(StreamReader &r)
+    {
+        Flag1 = r.ReadBool8();
+        Flag2 = r.ReadBool8();
+        Size = r.ReadU32();
+        r.Read(Data5, 5);
+        r.Read(Data3, 3);
+    }
+
+    void ThroughLayer::DrillHole::Load(StreamReader &r)
+    {
+        Net = r.ReadS32();
+        Tool = r.ReadU32();
+        Pos = r.ReadVec2S();
+    }
+
+    void ThroughLayer::DrillSlot::Load(StreamReader &r)
+    {
+        Net = r.ReadS32();
+        Tool = r.ReadU32();
+        Begin = r.ReadVec2S();
+        End = r.ReadVec2S();
+        Zero = r.ReadU32();
+    }
+
+    void ThroughLayer::Load(StreamReader &r)
+    {
+        Object::Load(r);
+        auto zero = r.ReadU32();
+        (void)zero;
+        R_ASSERT(zero == 0);
+        zero = r.ReadU32();
+        R_ASSERT(zero == 0);
+        auto toolCount = r.ReadU32();
+        if (toolCount == 0)
+            return; // empty through-layer: no tools, no drills
+        toolCount--;
+        Tools.reserve(toolCount);
+        for (uint32_t i = 0; i < toolCount; i++)
+        {
+            Tools.emplace_back();
+            Tools.back().Load(r);
+        }
+        zero = r.ReadU8();
+        R_ASSERT(zero == 0);
+        auto const drillCount = r.ReadU32();
+        {
+            auto v2 = r.ReadU32();
+            (void)v2;
+            TEBO_LOG("- drill holes[%u], v2[%u]\n", drillCount, v2);
+            // skip 4 zero dwords
+            uint32_t dummy[4];
+            r.Read(dummy, 4);
+            R_ASSERT(dummy[0] == 0);
+            R_ASSERT(dummy[1] == 0);
+            R_ASSERT(dummy[2] == 0);
+            R_ASSERT(dummy[3] == 0);
+        }
+        DrillHoles.reserve(drillCount);
+        // XXX: drill slot count must be stored somewhere
+        DrillSlots.reserve(100);
+        for (uint32_t i = 0; i < drillCount; i++)
+        {
+            switch (r.ReadU8())
+            {
+            case 0x08:
+                DrillHoles.emplace_back();
+                DrillHoles.back().Load(r);
+                continue;
+            case 0x0A:
+            case 0x0B:
+                DrillSlots.emplace_back();
+                DrillSlots.back().Load(r);
+                continue;
+            default:
+                R_ASSERT(!"Unrecognized drill code");
+            }
+        }
+    }
+
+    static std::unique_ptr<Object> LoadObject(StreamReader &r)
+    {
+        Object *object = nullptr;
+        ObjectType const type = Object::Detect(r);
+        switch (type)
+        {
+        case ObjectType::Logic:
+            object = new LogicLayer();
+            break;
+        case ObjectType::Through:
+            object = new ThroughLayer();
+            break;
+        default:
+            R_ASSERT(!"Unrecognized ObjectType");
+            break;
+        }
+        if (object)
+        {
+            object->Load(r);
+            TEBO_LOG("- done at addr[0x%08X]\n", uint32_t(r.Tell()));
+        }
+        return std::unique_ptr<Object>(object);
+    }
+
+    void ProbeBox32::Load(StreamReader &r)
+    {
+        Tag = r.ReadS32();
+        V1 = r.ReadVec2S();
+        V2 = r.ReadVec2S();
+    }
+
+    void DoubleBox32::Load(StreamReader &r)
+    {
+        Tag = r.ReadU32();
+        B1.Load(r);
+        B2.Load(r);
+    }
+
+    void ProbeBox8::Load(StreamReader &r)
+    {
+        Tag = r.ReadU8();
+        N = r.ReadS32();
+        A = r.ReadS32();
+        P1 = r.ReadS32();
+        P2 = r.ReadS32();
+    }
+
+    void ProbeDataItem::Load(StreamReader &r)
+    {
+        Present = r.ReadBool8();
+        if (Present)
+        {
+            Size = r.ReadS32();
+            r.Read(Params, 5);
+            Color = r.ReadU32();
+        }
+    }
+
+    void FixtureData::Load(StreamReader &r)
+    {
+        P1 = r.ReadU32();
+        r.Read(PX, 6);
+        r.Read(Flags, 3);
+        uint32_t const itemCount = r.ReadU32();
+        R_ASSERT(itemCount > 0);
+        Items.reserve(itemCount);
+        for (uint32_t i = 0; i < itemCount; i++)
+        {
+            Items.emplace_back();
+            Items.back().Load(r);
+        }
+        uint32_t const boxCount = r.ReadU32();
+        C1 = r.ReadU32();
+        V1 = r.ReadVec2S();
+        V2 = r.ReadVec2S();
+        Boxes.reserve(boxCount);
+        for (uint32_t i = 0; i < boxCount; i++)
+        {
+            Boxes.emplace_back();
+            Boxes.back().Load(r);
+        }
+    }
+
+    void ProbeData::Load(StreamReader &r)
+    {
+        Fixture.Load(r);
+        V3 = r.ReadVec2S();
+        V4 = r.ReadVec2S();
+        uint32_t const box2Count = r.ReadU32();
+        Boxes2.reserve(box2Count);
+        for (uint32_t i = 0; i < box2Count; i++)
+        {
+            Boxes2.emplace_back();
+            Boxes2.back().Load(r);
+        }
+    }
+
+    void Probe::Load(StreamReader &r)
+    {
+        Header.Flag = r.ReadBool8();
+        Header.Tag = r.ReadU32();
+        Header.Name = r.ReadString255();
+        Header.Size1 = r.ReadS32();
+        Header.Param1 = r.ReadU32();
+        Header.Size2 = r.ReadS32();
+        Header.Param2 = r.ReadU32();
+        Header.Size3 = r.ReadS32();
+        Header.Param3 = r.ReadU32();
+        Header.Color = r.ReadU32();
+        Header.K1 = r.ReadU32();
+        Header.V1 = r.ReadU32();
+        Header.K2 = r.ReadU32();
+        Header.V2 = r.ReadU32();
+        Header.K3 = r.ReadU32();
+        Header.V3 = r.ReadU32();
+        Header.K4 = r.ReadU32();
+        Header.V4 = r.ReadU32();
+        bool const hasBody = r.ReadBool8();
+        if (hasBody)
+        {
+            ProbeData body;
+            body.Load(r);
+            Body = std::make_unique<ProbeData>();
+            *Body = std::move(body);
+        }
+        Tail.Tag = r.ReadU32();
+        Tail.Flag1 = r.ReadBool8();
+        Tail.Flag2 = r.ReadBool8();
+        Tail.Flag3 = r.ReadBool8();
+        Tail.P0 = r.ReadU8();
+        Tail.P1 = r.ReadS32();
+        Tail.P2 = r.ReadS32();
+        Tail.P3 = r.ReadS32();
+        Tail.B1.Tag = r.ReadS32();
+        Tail.B1.V1 = r.ReadVec2S();
+        Tail.B1.V2 = r.ReadVec2S();
+        Tail.B2.Tag = r.ReadS32();
+        Tail.B2.V1 = r.ReadVec2S();
+        Tail.B2.V2 = r.ReadVec2S();
+    }
+
+    void ProbeRegistry::Load(StreamReader &r)
+    {
+        Z1 = r.ReadU32();
+        R_ASSERT(Z1 == 0);
+        Z2 = r.ReadU32();
+        R_ASSERT(Z2 == 0);
+        Param = r.ReadU32();
+        R_ASSERT(Param == 4);
+        Name = r.ReadString255();
+        DefaultSize = r.ReadU32();
+        uint32_t const packCount = r.ReadU32();
+        R_ASSERT(packCount > 0);
+        Packs.reserve(packCount);
+        for (uint32_t ip = 0; ip < packCount; ip++)
+        {
+            ProbePack pack;
+            uint32_t const probeCount = r.ReadU32();
+            for (uint32_t i = 0; i < probeCount; i++)
+            {
+                Probe p;
+                p.Load(r);
+                pack.push_back(std::move(p));
+            }
+            Packs.push_back(std::move(pack));
+        }
+    }
+
+    void FixtureVariant::Load(StreamReader &r)
+    {
+        Name = r.ReadString255();
+        ShortName = r.ReadString255();
+        Flag1 = r.ReadBool8();
+        Flag2 = r.ReadBool8();
+        Data.Load(r);
+    }
+
+    void FixtureSetting::Load(StreamReader &r)
+    {
+        Tag = r.ReadU32();
+        R_ASSERT(Tag == 3);
+        Name = r.ReadString255();
+        Param = r.ReadU32();
+        R_ASSERT(Param == 0);
+        uint32_t const variantCount = r.ReadU32();
+        Variants.reserve(variantCount);
+        for (uint32_t i = 0; i < variantCount; i++)
+        {
+            Variants.emplace_back();
+            Variants.back().Load(r);
+        }
+        WorkspaceSize = r.ReadVec2S();
+    }
+
+    void FixtureRegistry::Load(StreamReader &r)
+    {
+        Tag1 = r.ReadU32();
+        R_ASSERT(Tag1 == 0);
+        Tag2 = r.ReadU32();
+        R_ASSERT(Tag2 == 7874);
+        Grids.reserve(8);
+        for (uint32_t i = 0; i < 8; i++)
+            Grids.push_back(r.ReadString255());
+        Top.Load(r);
+        Bottom.Load(r);
+    }
+
+    void Pin::Load(StreamReader &r)
+    {
+        Handle = r.ReadU32();
+        Z1 = r.ReadU32();
+        R_ASSERT(Z1 == 0);
+        Id = r.ReadU32();
+        Name = r.ReadString255();
+        Z2 = r.ReadU32();
+        R_ASSERT(Z2 == 0);
+    }
+
+    void Part::Load(StreamReader &r)
+    {
+        Name = r.ReadString255();
+        Bbox.Min = r.ReadVec2S();
+        Bbox.Max = r.ReadVec2S();
+        Pos = r.ReadVec2S();
+        Angle = r.ReadS32();
+        Decal = r.ReadU32();
+        Type = PartType(r.ReadU32());
+        Z1 = r.ReadU32();
+        R_ASSERT(Z1 == 0);
+        Height = r.ReadS32();
+        Flag0 = r.ReadBool8();
+        Value = r.ReadString255();
+        ToleranceP = r.ReadString255();
+        ToleranceN = r.ReadString255();
+        Desc = r.ReadString255();
+        if (Flag0)
+        {
+            Serial = r.ReadString255();
+            Z2 = r.ReadU32();
+            R_ASSERT(Z2 == 0);
+        }
+        auto const pinCount = r.ReadU32();
+        Layer = r.ReadU32();
+        P2 = r.ReadU32();
+        R_ASSERT(P2 == 0);
+        Pins.reserve(pinCount);
+        for (uint32_t i = 0; i < pinCount; i++)
+        {
+            Pins.emplace_back();
+            Pins.back().Load(r);
+        }
+    }
+
+    void MysteriousBlock::Load(StreamReader &r)
+    {
+        P1 = r.ReadU32();
+        P2 = r.ReadU32();
+        TopRight = r.ReadVec2S();
+        P3 = r.ReadU32();
+        P4 = r.ReadU32();
+        Flag1 = r.ReadBool8();
+        Flag2 = r.ReadBool8();
+        P5 = r.ReadU8();
+        P6 = r.ReadU8();
+        r.Read(P7x, 4);
+        r.Read(Flags, 6);
+        P8 = r.ReadU32();
+        P9 = r.ReadU32();
+        P10 = r.ReadU32();
+        P11 = r.ReadU32();
+        P12 = r.ReadU8();
+        P13 = r.ReadU8();
+    }
+
+    void Decal::Load(StreamReader &r)
+    {
+        Flag1 = r.ReadBool8();
+        R_ASSERT(Flag1);
+        Name = r.ReadString255();
+        r.Read(HeaderParams, 3);
+        Flag = r.ReadBool8();
+        for (uint32_t i = 0; i < Layers.size(); i++)
+        {
+            bool const present = r.ReadBool8();
+            if (!present)
+                continue;
+            Layers[i] = LoadObject(r);
+        }
+        OutlineFlag = r.ReadBool8();
+        R_ASSERT(OutlineFlag);
+        Param = r.ReadU32();
+        N1 = r.ReadS32();
+        OutlineVertexCount = r.ReadU32();
+        Outline.reserve(OutlineVertexCount);
+        for (uint32_t i = 0; i < OutlineVertexCount; i++)
+        {
+            Vector2S const v = r.ReadVec2S();
+            Outline.push_back(v);
+        }
+        r.Read(Params, 2);
+    }
+
+    void Board::ReadNetList(StreamReader &r)
+    {
+        uint32_t const netCount = r.ReadU32();
+        uint32_t const nc2 = r.ReadU32();
+        (void)nc2;
+        R_ASSERT(netCount > 0 && netCount == nc2);
+        TEBO_LOG("- loading %u nets\n", netCount);
+        Nets.reserve(netCount);
+        for (uint32_t i = 0; i < netCount; i++)
+            Nets.push_back(r.ReadString255());
+    }
+
+    void Board::ReadParts(StreamReader &r)
+    {
+        uint32_t const partCount = r.ReadU32();
+        (void)partCount;
+        uint32_t const skip = r.ReadU32();
+        (void)skip;
+        TEBO_LOG("- loading %u parts\n", partCount);
+        Parts.reserve(partCount);
+        for (uint32_t i = 0; i < partCount; i++)
+        {
+            Parts.emplace_back();
+            Parts.back().Load(r);
+        }
+    }
+
+    void Board::ReadDecals(StreamReader &r)
+    {
+        uint32_t const c = r.ReadU32();
+        (void)c;
+        R_ASSERT(c == 3);
+        uint32_t decalCount = r.ReadU32();
+        TEBO_LOG("- loading %u decals\n", decalCount);
+        Decals.reserve(decalCount);
+        for (uint32_t i = 0; i < decalCount; i++)
+        {
+            Decals.emplace_back();
+            Decals.back().Load(r);
+        }
+    }
+
+    void Board::Read(std::istream &fs)
+    {
+        StreamReader r(fs);
+        Header.Load(r);
+        Layers.reserve(Header.LayerCount);
+        for (uint32_t li = 0; li < Header.LayerCount; li++)
+        {
+            std::unique_ptr<Object> layer = LoadObject(r);
+            Layers.push_back(std::move(layer));
+        }
+        { // skip 4 zero dwords
+            uint32_t dummy[4];
+            r.Read(dummy, 4);
+            R_ASSERT(dummy[0] == 0);
+            R_ASSERT(dummy[1] == 0);
+            R_ASSERT(dummy[2] == 0);
+            R_ASSERT(dummy[3] == 0);
+        }
+        ReadNetList(r);
+        Probes.Load(r);
+        Fixtures.Load(r);
+        Myb.Load(r);
+        ReadParts(r);
+        ReadDecals(r);
+        TEBO_LOG("- done reading at addr[0x%08X]\n", uint32_t(r.Tell()));
+    }
+} // namespace Tebo

--- a/src/openboardview/FileFormats/tebo/TeboBoard.cpp
+++ b/src/openboardview/FileFormats/tebo/TeboBoard.cpp
@@ -26,21 +26,21 @@ namespace Tebo
         {
             auto const skip = r.ReadVec2S();
             (void)skip;
-            return std::make_unique<Round>(size);
+            return std::unique_ptr<Round>(new Round(size));
         }
         case ShapeType::Rect:
         {
             auto const turn = r.ReadFloat();
             auto const skip = r.ReadS32();
             (void)skip;
-            return std::make_unique<Rect>(size, turn);
+            return std::unique_ptr<Rect>(new Rect(size, turn));
         }
         case ShapeType::Poly:
         {
             auto const skip = r.ReadU32();
             (void)skip;
             auto const name = r.ReadString255();
-            auto shape = std::make_unique<Poly>(size, name);
+            auto shape = std::unique_ptr<Poly>(new Poly(size, name));
             shape->BBox.Min = r.ReadVec2S();
             shape->BBox.Max = r.ReadVec2S();
             auto subObjCount = r.ReadU32();
@@ -76,7 +76,7 @@ namespace Tebo
         {
             auto const turn = r.ReadFloat();
             auto const cornerRadius = r.ReadS32();
-            return std::make_unique<RoundRect>(size, cornerRadius, turn);
+            return std::unique_ptr<RoundRect>(new RoundRect(size, cornerRadius, turn));
         }
         default:
             R_ASSERT(!"Unrecognized shape type");
@@ -746,7 +746,7 @@ namespace Tebo
         {
             ProbeData body;
             body.Load(r);
-            Body = std::make_unique<ProbeData>();
+            Body = std::unique_ptr<ProbeData>(new ProbeData());
             *Body = std::move(body);
         }
         Tail.Tag = r.ReadU32();

--- a/src/openboardview/FileFormats/tebo/TeboBoard.hpp
+++ b/src/openboardview/FileFormats/tebo/TeboBoard.hpp
@@ -1,0 +1,647 @@
+﻿/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2020 Pavel Kovalenko
+ */
+
+#pragma once
+
+#include "Common.hpp"
+#include "Fixed32.hpp"
+#include "StreamReader.hpp"
+#include "Box2.hpp"
+#include <istream> // std::istream
+#include <vector>
+#include <array>
+#include <memory> // std::unique_ptr
+#include <string>
+#include <cstring>
+
+namespace Tebo
+{
+    struct Box2S
+    {
+        Vector2S Min, Max;
+
+        Vector2S Size() const
+        { return Vector2S{Max.X-Min.X, Max.Y-Min.Y}; }
+
+        template <typename T>
+        operator Box2T<T>() const
+        { return Box2T<T>(Min, Max); }
+    };
+
+    inline void ValidatePos(Vector2S) {}
+
+    enum class LayerType : uint32_t
+    {
+        Document = 0,
+        Top = 1,
+        Bottom = 2,
+        Signal = 3,
+        Plane = 4, // PowerGround
+        SolderTop = 5,
+        SolderBottom = 6,
+        SilkTop = 7,
+        SilkBottom = 8,
+        PasteTop = 9,
+        PasteBottom = 10,
+        Drill = 11,
+        Roul = 12
+    };
+
+    enum class PrimitiveType
+    {
+        Line,
+        Arc,
+        Surface
+    };
+
+    enum class ShapeType
+    {
+        Round = 0,
+        Rect = 1,
+        RoundRect = 3,
+        Poly = 5,
+    };
+
+    struct Shape
+    {
+        ShapeType Type;
+        Vector2S Size;
+        std::string Name;
+        float Turn; // degrees
+
+        Shape(ShapeType shapeType, Vector2S shapeSize, float turn)
+        {
+            Type = shapeType;
+            Size = shapeSize;
+            Turn = turn;
+        }
+
+        virtual ~Shape() = 0;
+
+        static std::unique_ptr<Shape> Load(StreamReader &r);
+    };
+
+    inline Shape::~Shape() = default;
+
+    struct Round : public Shape
+    {
+        Round(Vector2S shapeSize) :
+            Shape(ShapeType::Round, shapeSize, 0)
+        {}
+    };
+
+    struct Rect : public Shape
+    {
+        Rect(Vector2S shapeSize, float turn) :
+            Shape(ShapeType::Rect, shapeSize, turn)
+        {}
+    };
+    
+    struct Poly : public Shape
+    {
+        struct Line
+        {
+            int32_t Param1, Param2, Param3; // 1, 0, 0
+            Vector2S Start, End;
+            Fixed32 Width;
+
+            void Load(StreamReader &r);
+        };
+
+        Box2S BBox;
+        std::vector<Poly::Line> Lines;
+        int32_t Flags[3] = {};
+        std::vector<Vector2S> Vertices;
+
+        Poly(Vector2S shapeSize, std::string const &shapeName) :
+            Shape(ShapeType::Poly, shapeSize, 0)
+        {
+            Name = shapeName;
+        }
+    };
+
+    struct RoundRect : public Shape
+    {
+    public:
+        Fixed32 CornerRadius;
+
+        RoundRect(Vector2S size, Fixed32 r, float turn) :
+            Shape(ShapeType::RoundRect, size, turn),
+            CornerRadius(r)
+        {}
+    };
+    
+    struct Pad
+    {
+        Tebo::Shape *Shape;
+        int32_t Net;
+        uint32_t DCode;
+        Vector2S Pos;
+        bool IsExposed;
+        bool IsCopper;
+        uint8_t TestpointParam; // 0 - smd pin, 1 - accessible, 2 - mask
+        // extensions
+        bool IsSomething = false;
+        struct TestPointData
+        {
+            uint8_t Data12[12] = {};
+        } TestPoint;
+        struct ExposedData
+        {
+            Vector2S Min = {};
+            Vector2S Max = {};
+        } Exposed;
+        bool HasHole = false;
+        uint8_t TailParam = 0;
+        struct HoleData
+        {
+            uint8_t Data7[7] = {};
+            Vector2S Size = {};
+            uint8_t Param = 0;
+        } Hole;
+    };
+
+    struct Primitive
+    {
+        int32_t Net;
+        PrimitiveType Type;
+        uint32_t DCode;
+
+        Primitive(PrimitiveType type)
+        { Type = type; }
+
+        virtual ~Primitive() = 0;
+    };
+
+    inline Primitive::~Primitive() = default;
+
+    struct Line : public Primitive
+    {
+        Vector2S StartPos, EndPos;
+
+        Line() : Primitive(PrimitiveType::Line)
+        {}
+    };
+
+    struct Arc : public Primitive
+    {
+        Vector2S Pos;
+        Fixed32 Radius;
+        float StartAngle, SweepAngle;
+
+        Arc() : Primitive(PrimitiveType::Arc)
+        {}
+    };
+
+    struct Cutout
+    {
+        uint32_t Tag;
+        uint32_t EdgeCount;
+        std::vector<Vector2S> Vertices;
+    };
+
+    struct Surface : public Primitive
+    {
+        uint32_t EdgeCount;
+        Fixed32 LineWidth;
+        uint32_t VoidCount;
+        std::vector<Vector2S> Vertices;
+        std::vector<Cutout> Voids;
+        uint32_t VoidFlags = 0;
+
+        Surface() : Primitive(PrimitiveType::Surface)
+        {
+            DCode = 0;
+        }
+    };
+
+    struct TvwHeader
+    {
+        std::string Type;
+        uint32_t Const1; // = 1
+        std::string Customer;
+        uint8_t Const2; // = 0
+        std::string Date;
+        uint8_t Const3[3]; // = {0, 0, 0}
+        uint32_t Size1;
+        uint32_t Size2;
+        uint32_t Size3;
+        uint32_t LayerCount;
+
+        void Load(StreamReader &r);
+    };
+
+    enum class ObjectType : uint32_t
+    {
+        Undefined = 0,
+        Through = 1,
+        Logic = 3
+    };
+
+    struct Object
+    {
+        ObjectType ObjType; // 3 or 1
+        uint32_t Magic[2]; // 2, 1
+        std::string Name;
+        std::string InitialName;
+        std::string InitialPath;
+        LayerType Type;
+        uint32_t PadColor;
+        uint32_t LineColor;
+
+        static ObjectType Detect(StreamReader &r);
+
+        Object(ObjectType objType)
+        {
+            R_ASSERT(objType == ObjectType::Logic || objType == ObjectType::Through);
+            ObjType = objType;
+        }
+
+        virtual ~Object() = default;
+
+        virtual void Load(StreamReader &r);
+    };
+
+    struct TestPoint
+    {
+        bool Flag1;
+        int32_t P1, Handle, P2;
+        int32_t P3;
+        Vector2S Pos;
+        int32_t P4;
+        bool Flag2;
+        int32_t P5, P6;
+        int32_t N;
+
+        void Load(StreamReader &r);
+    };
+
+    struct TestPoint2
+    {
+        uint32_t P1, Handle, P2;
+        Vector2S Pos;
+        Vector2S Pos1, Pos2;
+        bool Flag1, Flag2, Flag3;
+        uint32_t Nail;
+        int32_t Param;
+        bool Flag4, Flag5, Flag6;
+        int32_t N;
+
+        void Load(StreamReader &r);
+    };
+
+    struct TestNode
+    {
+        uint32_t Current, Next;
+        bool Flag;
+
+        void Load(StreamReader &r);
+    };
+
+    struct UnknownItem
+    {
+        std::string Name;
+        Vector2S Pos;
+        int32_t Z1;
+        int32_t Param1, Param2, Param3;
+        int32_t Z2, Z3;
+        bool Flags[3];
+        uint32_t Param4;
+
+        void Load(StreamReader &r);
+    };
+
+    struct LogicLayer : public Object
+    {
+        std::vector<std::unique_ptr<Shape>> Shapes;
+        std::vector<Pad> Pads;
+        std::vector<Line> Lines;
+        std::vector<Arc> Arcs;
+        std::vector<Surface> Surfaces;
+        uint32_t UnknownItemCount;
+        uint32_t UnknownItemsParam;
+        std::vector<UnknownItem> UnknownItems;
+        uint32_t TpCount;
+        std::vector<TestPoint> TestPoints;
+        uint32_t TPS2Size;
+        uint32_t TPS2Param;
+        std::vector<TestPoint2> TestPoints2; // first tps
+        uint32_t TPS3Size;
+        uint32_t TPS3Param;
+        std::vector<TestPoint2> TestPoints3; // assistant tps
+        uint32_t TestSequenceSize;
+        uint32_t TestSequenceParam;
+        std::vector<TestNode> TestSequence;
+
+        LogicLayer() : Object(ObjectType::Logic)
+        {}
+
+        void LoadShapes(StreamReader &r);
+        void LoadPads(StreamReader &r);
+        void LoadLines(StreamReader &r);
+        void LoadArcs(StreamReader &r);
+        void LoadSurfaces(StreamReader &r);
+        void LoadUnknownItems(StreamReader &r);
+        void LoadTestpoints(StreamReader &r);
+        virtual void Load(StreamReader &r) override;
+    };
+
+    struct ThroughLayer : public Object
+    {
+        struct Tool
+        {
+            bool Flag1, Flag2;
+            Fixed32 Size;
+            uint32_t Data5[5];
+            uint8_t Data3[3]; // color?
+
+            void Load(StreamReader &r);
+        };
+        std::vector<Tool> Tools;
+        struct DrillHole
+        {
+            //uint8_t Code; // = 0x08
+            int32_t Net;
+            uint32_t Tool; // 1-based index
+            Vector2S Pos;
+
+            void Load(StreamReader &r);
+        };
+        std::vector<DrillHole> DrillHoles;
+        struct DrillSlot
+        {
+            //uint8_t Code; // = 0x0A
+            int32_t Net;
+            uint32_t Tool;
+            Vector2S Begin, End;
+            uint32_t Zero; // = 0
+
+            void Load(StreamReader &r);
+        };
+        std::vector<DrillSlot> DrillSlots;
+
+        ThroughLayer() : Object(ObjectType::Through)
+        {}
+    
+        virtual void Load(StreamReader &r) override;
+    };
+    
+    struct ProbeBox32
+    {
+        int32_t Tag;
+        Vector2S V1, V2;
+
+        void Load(StreamReader &r);
+    };
+
+    struct DoubleBox32
+    {
+        uint32_t Tag;
+        ProbeBox32 B1, B2;
+
+        void Load(StreamReader &r);
+    };
+
+    struct ProbeBox8
+    {
+        int8_t Tag;
+        int32_t N, A, P1, P2;
+
+        void Load(StreamReader &r);
+    };
+
+    struct ProbeDataItem
+    {
+        bool Present = false;
+        Fixed32 Size = 0;
+        uint32_t Params[5] = {};
+        uint32_t Color = 0;
+
+        void Load(StreamReader &r);
+    };
+
+    struct FixtureData
+    {
+        uint32_t P1;
+        uint32_t PX[6];
+        bool Flags[3];
+        std::vector<ProbeDataItem> Items;
+        // u32 ProbeBox8_count
+        uint32_t C1;
+        Vector2S V1, V2;
+        std::vector<ProbeBox8> Boxes;
+
+        void Load(StreamReader &r);
+    };
+
+    struct ProbeData
+    {
+        FixtureData Fixture;
+        Vector2S V3, V4;
+        std::vector<DoubleBox32> Boxes2;
+
+        void Load(StreamReader &r);
+    };
+
+    struct Probe
+    {
+        struct
+        {
+            bool Flag; // 01
+            uint32_t Tag; // 15
+            std::string Name; // "Spear_B_100 Mil"
+            Fixed32 Size1; // 7000
+            uint32_t Param1; // 0x0012CCFC
+            Fixed32 Size2; // 2000
+            uint32_t Param2; // 98
+            Fixed32 Size3; // 3000
+            uint32_t Param3; // 5299
+            uint32_t Color; // 0x0000FFFF
+            uint32_t K1, V1;
+            uint32_t K2, V2;
+            uint32_t K3, V3;
+            uint32_t K4, V4;
+        } Header;
+        std::unique_ptr<ProbeData> Body;
+        struct
+        {
+            uint32_t Tag;
+            bool Flag1, Flag2, Flag3;
+            uint8_t P0;
+            int32_t P1, P2, P3;        
+            ProbeBox32 B1, B2;
+        } Tail;
+
+        void Load(StreamReader &r);
+    };
+
+    using ProbePack = std::vector<Probe>;
+
+    struct ProbeRegistry
+    {
+        uint32_t Z1, Z2; // 0, 0
+        uint32_t Param; // 4
+        std::string Name;
+        Fixed32 DefaultSize; // 118.11 mil = 3 mm
+        std::vector<ProbePack> Packs;
+
+        void Load(StreamReader &r);
+    };
+
+    struct FixtureVariant
+    {
+        std::string Name;
+        std::string ShortName;
+        bool Flag1; // = 1
+        bool Flag2; // = 0
+        FixtureData Data;
+
+        void Load(StreamReader &r);
+    };
+
+    struct FixtureSetting
+    {
+        uint32_t Tag;
+        std::string Name;
+        uint32_t Param;
+        std::vector<FixtureVariant> Variants;
+        Vector2S WorkspaceSize;
+
+        void Load(StreamReader &r);
+    };
+
+    struct FixtureRegistry
+    {
+        uint32_t Tag1; // must be 0
+        uint32_t Tag2; // must be 7874
+        std::vector<std::string> Grids;
+        FixtureSetting Top, Bottom;
+
+        void Load(StreamReader &r);
+    };
+
+    struct Pin
+    {
+        uint32_t Handle;
+        uint32_t Z1;
+        uint32_t Id;
+        std::string Name;
+        uint32_t Z2;
+
+        void Load(StreamReader &r);
+    };
+
+    enum class PartType : uint32_t
+    {
+        Chip = 0,
+        Diode = 1,
+        Transistor = 2,
+        Resistor = 3,
+        Unknown4 = 4,
+        Capacitor = 5, // some fiducials (CFxx) go there for some reason
+        Unknown6 = 6,
+        Unknown7 = 7,
+        Unknown8 = 8,
+        Jumper = 9,
+        Unknown10 = 10,
+        Unknown11 = 11,
+        Unknown12 = 12,
+        Fuse = 13,
+        Choke = 14,
+        Oscillator = 15,
+        Switch = 16,
+        Connector = 17,
+        Testpoint = 18, // transformers go there as well
+        Unknown19 = 19,
+        Unknown20 = 20,
+        Mechanical = 21,
+        Fiducial = 29, // FDxx
+    };
+
+    struct Part
+    {
+        std::string Name;
+        Box2S Bbox;
+        Vector2S Pos;
+        int32_t Angle;
+        uint32_t Decal;
+        PartType Type;
+        uint32_t Z1;
+        Fixed32 Height;
+        bool Flag0;
+        std::string Value;
+        std::string ToleranceP;
+        std::string ToleranceN;
+        std::string Desc;
+        std::string Serial;
+        uint32_t Z2 = 0;
+        // uint32_t PinCount
+        uint32_t Layer; // 3 / 12
+        uint32_t P2; // 0
+        std::vector<Pin> Pins;
+
+        void Load(StreamReader &r);
+    };
+
+    struct MysteriousBlock
+    {
+        uint32_t P1, P2; // 50, 12452
+        Vector2S TopRight;
+        uint32_t P3, P4; // 3, 1
+        bool Flag1, Flag2;
+        uint8_t P5, P6;
+        uint32_t P7x[4];
+        bool Flags[6];
+        uint32_t P8; // 10000
+        uint32_t P9, P10, P11;
+        uint8_t P12, P13;
+
+        void Load(StreamReader &r);
+    };
+
+    struct Decal
+    {
+        bool Flag1;
+        std::string Name;
+
+        uint32_t HeaderParams[3];
+        bool Flag;
+        std::array<std::unique_ptr<Object>, 3> Layers;
+    
+        bool OutlineFlag;
+        uint32_t Param; // 2
+        int32_t N1; // -1
+        uint32_t OutlineVertexCount; // 8
+        std::vector<Vector2S> Outline;
+        uint32_t Params[2]; // 0, 0
+
+        void Load(StreamReader &r);
+    };
+
+    class Board
+    {
+    public:
+        TvwHeader Header;
+        std::vector<std::unique_ptr<Object>> Layers;
+        std::vector<std::string> Nets;
+        ProbeRegistry Probes;
+        FixtureRegistry Fixtures;
+        MysteriousBlock Myb;
+        std::vector<Part> Parts;
+        std::vector<Decal> Decals;
+
+    private:
+        void ReadNetList(StreamReader &r);
+        void ReadParts(StreamReader &r);
+        void ReadDecals(StreamReader &r);
+
+    public:
+        void Read(std::istream &fs);
+    };
+} // namespace Tebo

--- a/src/openboardview/FileFormats/tebo/Vector2.hpp
+++ b/src/openboardview/FileFormats/tebo/Vector2.hpp
@@ -28,7 +28,10 @@ struct Vector2T
         Y(y)
     {}
 
-    constexpr Scalar &operator[](size_t i)
+    // not constexpr: a C++11 constexpr member is implicitly const, which
+    // would collide with the const overload below, and its body may hold
+    // only a return - not this switch and assert.
+    Scalar &operator[](size_t i)
     {
         switch (i)
         {
@@ -38,7 +41,7 @@ struct Vector2T
         }
     }
 
-    constexpr Scalar const &operator[](size_t i) const
+    Scalar const &operator[](size_t i) const
     { return const_cast<Vector2T &>(*this)[i]; }
 
     constexpr Vec2 operator+(Vec2 v) const
@@ -59,16 +62,16 @@ struct Vector2T
     constexpr Vec2 operator/(Scalar s) const
     { return Vec2(X/s, Y/s); }
 
-    constexpr Vec2 &operator+=(Scalar s)
+    Vec2 &operator+=(Scalar s)
     { return *this = *this + s; }
 
-    constexpr Vec2 &operator-=(Scalar s)
+    Vec2 &operator-=(Scalar s)
     { return *this = *this - s; }
 
-    constexpr Vec2 &operator+=(Vec2 v)
+    Vec2 &operator+=(Vec2 v)
     { return *this = *this + v; }
 
-    constexpr Vec2 &operator-=(Vec2 v)
+    Vec2 &operator-=(Vec2 v)
     { return *this = *this - v; }
 
     constexpr Vec2 operator-() const
@@ -107,15 +110,11 @@ struct Vector2T
     Vec2 Normalize() const
     { return *this / Length(); }
 
-private:
-    template <typename T>
-    static constexpr bool IsFP = std::is_floating_point<T>::value;
-
-public:
     // non-fp to anything, fp to other fp
     template <typename T,
         typename S = Scalar,
-        typename = std::enable_if_t<!IsFP<S> || IsFP<S> && IsFP<T>>
+        typename = typename std::enable_if<!std::is_floating_point<S>::value ||
+            (std::is_floating_point<S>::value && std::is_floating_point<T>::value)>::type
     >
     constexpr operator Vector2T<T>() const
     { return {T(X), T(Y)}; }
@@ -124,7 +123,8 @@ public:
     template <typename T,
         typename = void,
         typename S = Scalar,
-        typename = std::enable_if_t<IsFP<S> && !IsFP<T>>
+        typename = typename std::enable_if<std::is_floating_point<S>::value &&
+            !std::is_floating_point<T>::value>::type
     >
     operator Vector2T<T>() const
     { return {T(std::round(X)), T(std::round(Y))}; }

--- a/src/openboardview/FileFormats/tebo/Vector2.hpp
+++ b/src/openboardview/FileFormats/tebo/Vector2.hpp
@@ -1,0 +1,155 @@
+/*
+ * Tebo-ICT View (.tvw) board format parser
+ * By: Pavel Kovalenko
+ * Source: https://github.com/nitrocaster/eagleview
+ *
+ * MIT License
+ * Copyright (c) 2019 Pavel Kovalenko
+ */
+
+#pragma once
+
+#include "Common.hpp"
+#include <limits> // std::numeric_limits
+#include <cmath> // std::abs
+#include <type_traits> // enable_if, is_floating_point
+
+template <typename Scalar>
+struct Vector2T
+{
+    using Vec2 = Vector2T<Scalar>;
+
+    Scalar X, Y;
+
+    Vector2T() = default;
+
+    constexpr Vector2T(Scalar x, Scalar y) :
+        X(x),
+        Y(y)
+    {}
+
+    constexpr Scalar &operator[](size_t i)
+    {
+        switch (i)
+        {
+        case 0: return X;
+        case 1: return Y;
+        default: R_ASSERT(!"Index out of range");
+        }
+    }
+
+    constexpr Scalar const &operator[](size_t i) const
+    { return const_cast<Vector2T &>(*this)[i]; }
+
+    constexpr Vec2 operator+(Vec2 v) const
+    { return Vec2(X+v.X, Y+v.Y); }
+
+    constexpr Vec2 operator-(Vec2 v) const
+    { return Vec2(X-v.X, Y-v.Y); }
+
+    constexpr Vec2 operator+(Scalar s) const
+    { return Vec2(X+s, Y+s); }
+
+    constexpr Vec2 operator-(Scalar s) const
+    { return Vec2(X-s, Y-s); }
+
+    constexpr Vec2 operator*(Scalar s) const
+    { return Vec2(X*s, Y*s); }
+
+    constexpr Vec2 operator/(Scalar s) const
+    { return Vec2(X/s, Y/s); }
+
+    constexpr Vec2 &operator+=(Scalar s)
+    { return *this = *this + s; }
+
+    constexpr Vec2 &operator-=(Scalar s)
+    { return *this = *this - s; }
+
+    constexpr Vec2 &operator+=(Vec2 v)
+    { return *this = *this + v; }
+
+    constexpr Vec2 &operator-=(Vec2 v)
+    { return *this = *this - v; }
+
+    constexpr Vec2 operator-() const
+    { return Vec2(-X, -Y); }
+
+    constexpr Vec2 operator+() const
+    { return *this; }
+
+    constexpr Scalar SqrLength() const
+    { return X*X + Y*Y; }
+
+    constexpr bool operator<(Vec2 v2) const
+    { return SqrLength() < v2.SqrLength(); }
+
+    constexpr bool operator>(Vec2 v2) const
+    { return SqrLength() > v2.SqrLength(); }
+
+    constexpr bool operator<=(Vec2 v2) const
+    { return SqrLength() <= v2.SqrLength(); }
+
+    constexpr bool operator>=(Vec2 v2) const
+    { return SqrLength() >= v2.SqrLength(); }
+
+    bool operator==(Vec2 v2) const
+    { return std::abs(X-v2.X) <= ScalarEps && std::abs(Y-v2.Y) <= ScalarEps; }
+
+    bool operator!=(Vec2 v2) const
+    { return !(*this==v2); }
+
+    Scalar Length() const
+    { return std::sqrt(SqrLength()); }
+
+    Scalar Magnitude() const
+    { return Length(); }
+
+    Vec2 Normalize() const
+    { return *this / Length(); }
+
+private:
+    template <typename T>
+    static constexpr bool IsFP = std::is_floating_point<T>::value;
+
+public:
+    // non-fp to anything, fp to other fp
+    template <typename T,
+        typename S = Scalar,
+        typename = std::enable_if_t<!IsFP<S> || IsFP<S> && IsFP<T>>
+    >
+    constexpr operator Vector2T<T>() const
+    { return {T(X), T(Y)}; }
+
+    // fp to non-fp
+    template <typename T,
+        typename = void,
+        typename S = Scalar,
+        typename = std::enable_if_t<IsFP<S> && !IsFP<T>>
+    >
+    operator Vector2T<T>() const
+    { return {T(std::round(X)), T(std::round(Y))}; }
+
+private:
+    using Limits = std::numeric_limits<Scalar>;
+
+public:
+    static constexpr Scalar ScalarEps{Limits::epsilon()};
+    static const Vec2 MinValue;
+    static const Vec2 MaxValue;
+    static const Vec2 Epsilon;
+    static const Vec2 Origin;
+};
+
+using Vector2 = Vector2T<float>;
+using Vector2f = Vector2T<float>;
+using Vector2d = Vector2T<double>;
+using Vector2i = Vector2T<int32_t>;
+
+template <typename Scalar>
+CONSTEXPR_DEF Vector2T<Scalar> Vector2T<Scalar>::MinValue{Limits::min(), Limits::min()};
+template <typename Scalar>
+CONSTEXPR_DEF Vector2T<Scalar> Vector2T<Scalar>::MaxValue{Limits::max(), Limits::max()};
+template <typename Scalar>
+CONSTEXPR_DEF Vector2T<Scalar> Vector2T<Scalar>::Epsilon{ScalarEps, ScalarEps};
+template <typename Scalar>
+CONSTEXPR_DEF Vector2T<Scalar> Vector2T<Scalar>::Origin{0, 0};


### PR DESCRIPTION
Fixes #291.

## What this does

OpenBoardView currently rejects Tebo-ICT View (`.tvw`) files with
"Unrecognized file format.". This adds a native reader 

Copper/plane rendering is **not** part of this PR, it's a separate,
larger change on top of this one.

## Where the parser comes from

The binary container parser in `FileFormats/tebo/` is Pavel Kovalenko's
reverse-engineered implementation from
[eagleview](https://github.com/nitrocaster/eagleview), headers reformatted to match this project's
`Crypto/des.c` convention). `FileFormats/TVWFile.cpp` is a thin adapter
mapping the parsed board onto `BRDFileBase`.

Changes relative to upstream eagleview:
- assertions throw instead of calling `__builtin_trap()`, so a malformed
  file surfaces as a load error instead of taking the application down
- an empty through-layer (`toolCount == 0`) is accepted; upstream
  asserted, which rejected most of the Lenovo/LCFC boards tested
- diagnostics are behind `TEBO_VERBOSE` (off) rather than `printf`
- kept C++11-compatible, since this target builds as C++11

## How it works

- **Detection** is by content, not extension: every `.tvw` begins with a
  length-prefixed, character-ciphered type string that decodes to
  `"Tebo-ictview files."`.
- **Pin → net resolution** is two hops, undocumented in the file itself:
  `Pin.Handle / 8` indexes into that layer's `Pads` array, and
  `Pad.Net` indexes into the board's net table. A `Pin` record carries
  no net field directly.
- **Per-layer field order varies.** A layer's header carries a flag
  (`1` = normal order, `2` = extra data appended after surfaces) that
  changes where lines/arcs are re-read from. Getting this wrong desyncs
  the stream silently for every layer after it, so it's asserted rather
  than assumed.
- **Board outline** comes from the real route/fab layer (`Roul`/OUTLINE)
  when present; falls back to a bounding box around all pins when it
  isn't, or when the route data looks unusable (stray far-out segments).
- Net names are interned once into a `std::deque<std::string>` (not
  `std::vector`) so pointers handed out via `intern()` survive later
  growth.

## Testing

9 boards (Lenovo Yoga/Legion/ThinkBook, LCFC), 22k pins on the largest —
all load, every pin resolves to a named net. Malformed/truncated inputs
were fuzzed and produce a clean load error rather than a crash.