### PR TITLE
Add an optional AI-assisted diagnostics checklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ CPackSourceConfig.cmake
 
 include/version.h
 share
+__pycache__/
+*.py[cod]
 
 # macOS specific
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ replacement for the "Test_Link" software and "Landrex".
 - Non-orthagonally orientated caps/resistors/diodes now drawn more realistically
 - Adjustable DPI (for working on 2K/4K screens)
 - Works with multiple concurrent instances
+- Optional AI-assisted diagnostic checklists beside the boardview
 
 
 ### TODO
@@ -87,6 +88,11 @@ $ open ./openboardview.app
 ```
 
 ### Usage
+
+When diagnostics support is built, OpenBoardView installs its portable `board-diagnostics`
+skill for Codex/OpenCode in `~/.agents/skills` and for Claude Code in
+`~/.claude/skills` on first launch. Existing skills not managed by OpenBoardView are
+left untouched. The skill requires Python 3.
 
 - Ctrl-O: Open file select dialog
 

--- a/skills/board-diagnostics/SKILL.md
+++ b/skills/board-diagnostics/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: board-diagnostics
+description: Create, open, and review ticket-based motherboard diagnostic checklists inside OpenBoardView. Use when the user gives a board fault and wants a measurement plan, refers to a repair ticket, says board checks are done, or wants the next diagnostic round.
+license: MIT
+---
+
+# Board Diagnostics
+
+Turn a board-repair conversation into substantial, self-contained measurement rounds instead of conversational micro-steps.
+
+## Local tool
+
+Resolve `scripts/board_diagnostics.py` relative to this `SKILL.md`. Run it with Python 3. It stores durable cases under `~/.local/share/board-diagnostics/tickets/<ticket>/case.json`. Opening a ticket loads the matching board file, shows the Diagnostics pane, and raises an existing matching OpenBoardView window instead of starting a duplicate.
+
+Read [the checklist plan schema](references/checklist-plan.md) before creating or appending a measurement round.
+
+## Start a case
+
+1. Require a ticket number, board identity, and initial fault. The ticket number is the project key. If it is missing, ask for it in one concise question; collect any other genuinely required missing fact in that same question.
+2. Inspect the available schematic, boardview, prior notes, and other case artifacts before choosing test points. Reuse the user's established board orientation when available.
+3. Build one useful first-pass round containing every currently justified check that can materially narrow the fault. Let diagnostic value determine the length: do not target a fixed count, pad the round with filler, or omit useful checks merely to keep it short. Organize it by physical side, then by meter mode and power state, to minimize board flips, power cycling, and meter changes.
+   When existing evidence strongly supports one diagnosis, prefer the smallest decisive confirmation set over a broad exploratory round.
+4. Give each decision-point measurement a stable `key`. Add `requires_pass` to downstream checks only when a failed/not-measurable prerequisite genuinely makes those checks unnecessary. The app will hold dependent rows until prerequisites pass and automatically mark them skipped when a prerequisite fails.
+5. Keep the top-of-window summary to one concise sentence, or at most two. Do not repeat the full fault history there. Omit global `instructions` unless one short instruction is essential and cannot live in a section's safety or probe text.
+6. Write the plan JSON in the case workspace at `.board-diagnostics/plans/<ticket>-round-<n>.json`. Preserve this source plan as part of the ticket record.
+7. Run `validate-plan`, then `create --open` for round 1 or `add-round --open` for a later round. Fix validation errors before opening the app. If the user rejects an untouched unfinished round, use `replace-round --open`; it refuses to discard recorded readings, statuses, notes, or comments.
+8. Ensure the ticket is visible in OpenBoardView before responding. If that board is already open, reuse and focus its window instead of launching another instance. Tell the user briefly that the whole round is ready and ask them to say they are done with the ticket after pressing **Finish round**.
+
+Do not interrupt a round with conversational micro-steps. If new physical measurements are needed after review, create the complete next batch as another round and open it.
+
+## Window handoff
+
+Whenever ticket work leaves a checklist ready for the user, opening or focusing OpenBoardView must be the final task action before responding. Use the CLI's `--open` option when creating, adding, or replacing a round, or run `open --ticket <ticket>` when no write is needed. Use `open --ticket <ticket> --target <component-or-net>` when a specific point should be shown immediately. Do not give the user deep links, file links, or manual-opening instructions unless they explicitly ask how to open it themselves.
+
+## Measurement quality and safety
+
+- Never invent a rail, component reference, board location, expected value, or probe polarity. Ground each check in the available board/schematic evidence or clearly label the expectation as an investigative comparison.
+- Include units and a meaningful expected value or range. State probe polarity for diode measurements and any non-obvious reference point.
+- Keep `expected` compact because it seeds the editable Actual field; prefer a nominal such as `3.3 V` and put tolerances or comparison rules in `why`.
+- Each row gets a Boardview button. The app normally infers its search target from the component designator in `point`; set `boardview` explicitly when the row should jump to a different component or net.
+- Voltage checks may specify connected power when justified. Diode, resistance, and continuity sections must be unpowered: disconnect charger and battery and allow rails to discharge before measuring.
+- Prefer checks with high diagnostic value and low risk. Cover the complete currently justified decision tree in one batch, including comparison points when they distinguish a local fault from a shared path. Avoid repeating readings already established unless they are needed as a live baseline for the new batch.
+- Use Side A and Side B tabs even when one side has no checks in a particular round.
+
+## Review completed work
+
+When the user says they are done:
+
+1. Use the ticket from the active conversation. If it is not unambiguous, ask only for the ticket number.
+2. Run `status --ticket <ticket> --json`. If the case is not `waiting_for_ai`, report how many rows remain and do not pretend the round is complete.
+3. Run `results --ticket <ticket>`. Treat `actual`, right/wrong/not-measurable states, and Side A/B comments as the evidence of record.
+4. Explain the significant results, rank the likely fault area, state uncertainty, and distinguish measured facts from inference.
+5. If more bench work is needed, create and open one complete follow-up round under the same ticket. If not, give the conclusion and repair/verification next steps directly.
+
+Use `list` when the user asks which cases exist. It returns projects in natural ticket-number order.

--- a/skills/board-diagnostics/references/checklist-plan.md
+++ b/skills/board-diagnostics/references/checklist-plan.md
@@ -1,0 +1,101 @@
+# Checklist plan schema
+
+Use this JSON format as input to `board_diagnostics.py create` and `add-round`. The CLI adds result fields, stable IDs, timestamps, and the round number.
+
+```json
+{
+  "title": "Initial checks",
+  "summary": "One sentence explaining the purpose of this round.",
+  "instructions": [
+    "Use the stated power condition for each section.",
+    "Adjust the prefilled actual reading when the measured value differs."
+  ],
+  "sides": [
+    {
+      "name": "Side A",
+      "sections": [
+        {
+          "title": "With power connected",
+          "mode": "voltage",
+          "power_state": "connected",
+          "safety": "Use a current-limited supply and avoid probe slips.",
+          "measurements": [
+            {
+              "key": "input_present",
+              "point": "EVIDENCE_BACKED_TEST_POINT",
+              "reference": "GROUND_OR_OTHER_REFERENCE",
+              "expected": "EXPECTED_VALUE_OR_RANGE_WITH_UNIT",
+              "boardview": "COMPONENT_OR_NET_TO_FIND",
+              "requires_pass": [],
+              "probe": "Describe probe placement when it is not obvious.",
+              "location": "Optional boardview location hint.",
+              "why": "Optional diagnostic reason for this check."
+            }
+          ]
+        },
+        {
+          "title": "Diode mode",
+          "mode": "diode",
+          "power_state": "disconnected",
+          "safety": "Disconnect charger and battery and let rails discharge.",
+          "measurements": []
+        },
+        {
+          "title": "Resistance",
+          "mode": "resistance",
+          "power_state": "disconnected",
+          "safety": "Disconnect charger and battery and let rails discharge.",
+          "measurements": []
+        }
+      ]
+    },
+    {
+      "name": "Side B",
+      "sections": []
+    }
+  ]
+}
+```
+
+## Fields
+
+- `title` is required for every round.
+- `summary` is optional but useful for explaining the test strategy.
+- `instructions` is an optional array of short strings shown above the tabs.
+- `sides` must contain at least `Side A` and `Side B`.
+- `sections` may be empty. Supported modes are `voltage`, `diode`, `resistance`, `continuity`, and `other`.
+- `power_state` is required. Diode, resistance, and continuity accept only `disconnected`, `unpowered`, or `off`.
+- Every measurement requires `point`, `reference`, and `expected`. `probe`, `location`, and `why` are optional.
+- `key` is an optional unique stable identifier. Use it on prerequisite and dependent rows.
+- `requires_pass` is an optional array of measurement keys. A dependent row waits until every prerequisite passes; a failed, not-measurable, or skipped prerequisite automatically marks it skipped. Do not use it when the downstream result would still add diagnostic value.
+- `boardview` optionally names the exact component or net opened by the row's Boardview button. When omitted, the app infers the first component designator in `point`.
+- Keep `expected` short enough to edit comfortably because it is also the initial Actual value. Put acceptable ranges and comparison details in `why`.
+- Do not put measured results in a plan. The app initializes editable `actual` fields from `expected` and adds `status` and `note` fields. Prefilling does not mark a row as tested.
+
+## Commands
+
+Resolve the script path relative to the skill, then run:
+
+```bash
+python3 scripts/board_diagnostics.py validate-plan --plan <plan.json>
+
+python3 scripts/board_diagnostics.py create \
+  --ticket <ticket> \
+  --board <board-identity> \
+  --issue <initial-fault> \
+  --workspace <case-folder> \
+  --plan <plan.json> \
+  --open
+
+python3 scripts/board_diagnostics.py add-round \
+  --ticket <ticket> \
+  --plan <plan.json> \
+  --open
+
+python3 scripts/board_diagnostics.py replace-round \
+  --ticket <ticket> \
+  --plan <plan.json> \
+  --open
+```
+
+Quote command arguments safely. Do not replace an existing ticket. Use `replace-round` only for an untouched unfinished active round that the user explicitly rejects; otherwise append a round so measurement history remains intact.

--- a/skills/board-diagnostics/scripts/board_diagnostics.py
+++ b/skills/board-diagnostics/scripts/board_diagnostics.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Command-line bridge between AI assistants and OpenBoardView diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import board_diagnostics_core as core
+
+
+BOARD_EXTENSIONS = {".brd", ".bdv", ".bvr", ".fz", ".asc", ".bom", ".cad", ".cae", ".cst", ".pcb"}
+
+
+def board_files(case: dict) -> list[Path]:
+    workspace = Path(str(case.get("source_workspace", ""))).expanduser()
+    if not workspace.is_dir():
+        return []
+    return sorted(
+        path.resolve()
+        for path in workspace.rglob("*")
+        if path.is_file() and path.suffix.casefold() in BOARD_EXTENSIONS
+    )
+
+
+def write_open_request(case: dict, board_file: Path, target: str = "") -> tuple[Path, str]:
+    request_path = core.data_root().parent / "open-request.json"
+    request_id = uuid.uuid4().hex
+    core.atomic_write_json(
+        request_path,
+        {
+            "request_id": request_id,
+            "ticket": case["ticket"],
+            "board_file": str(board_file),
+            "target": str(target).strip(),
+            "requested_at": core.now_utc(),
+        },
+    )
+    return request_path, request_id
+
+
+def request_was_handled(request_id: str) -> bool:
+    acknowledgement = core.data_root().parent / "open-request-ack.json"
+    try:
+        payload = json.loads(acknowledgement.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("request_id") == request_id
+
+
+def wait_for_acknowledgement(request_id: str, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if request_was_handled(request_id):
+            return True
+        time.sleep(0.05)
+    return request_was_handled(request_id)
+
+
+def add_common_ticket(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--ticket", required=True, help="Case ticket number, with optional leading #")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="board-diagnostics",
+        description="Create, open, and read ticket-based motherboard diagnostic checklists.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="Create the first checklist round for a ticket")
+    add_common_ticket(create)
+    create.add_argument("--board", required=True, help="Board/device identifier")
+    create.add_argument("--issue", required=True, help="Initial reported fault")
+    create.add_argument("--plan", required=True, type=Path, help="Checklist plan JSON")
+    create.add_argument("--workspace", type=Path, default=Path.cwd(), help="Source case folder")
+    create.add_argument("--open", action="store_true", help="Open OpenBoardView after creation")
+
+    follow_up = subparsers.add_parser("add-round", help="Append a follow-up checklist to a ticket")
+    add_common_ticket(follow_up)
+    follow_up.add_argument("--plan", required=True, type=Path, help="Checklist plan JSON")
+    follow_up.add_argument("--open", action="store_true", help="Open OpenBoardView after appending")
+
+    replace = subparsers.add_parser(
+        "replace-round", help="Replace an untouched unfinished checklist round"
+    )
+    add_common_ticket(replace)
+    replace.add_argument("--plan", required=True, type=Path, help="Replacement checklist plan JSON")
+    replace.add_argument("--open", action="store_true", help="Open OpenBoardView after replacement")
+
+    open_parser = subparsers.add_parser("open", help="Open a ticket in OpenBoardView")
+    add_common_ticket(open_parser)
+    open_parser.add_argument("--target", default="", help="Component or net to show on the board")
+
+    results = subparsers.add_parser("results", help="Read all measurements for a ticket")
+    add_common_ticket(results)
+    results.add_argument("--json", action="store_true", help="Print raw case JSON")
+
+    status = subparsers.add_parser("status", help="Show current progress for a ticket")
+    add_common_ticket(status)
+    status.add_argument("--json", action="store_true", help="Print machine-readable progress")
+
+    list_parser = subparsers.add_parser("list", help="List projects in natural ticket order")
+    list_parser.add_argument("--json", action="store_true", help="Print machine-readable case list")
+
+    validate = subparsers.add_parser("validate-plan", help="Validate and normalize a plan without saving")
+    validate.add_argument("--plan", required=True, type=Path, help="Checklist plan JSON")
+    validate.add_argument("--round", type=int, default=1, help="Round number used for generated IDs")
+
+    return parser
+
+
+def launch_app(ticket: str, target: str = "") -> int:
+    clean_ticket = core.normalize_ticket(ticket)
+    case = core.load_case(clean_ticket)
+    files = board_files(case)
+    if not files:
+        raise core.DiagnosticError(
+            f"no supported boardview file found under {case.get('source_workspace', '')}"
+        )
+
+    board_file = files[0]
+    _request_path, request_id = write_open_request(case, board_file, target)
+    if wait_for_acknowledgement(request_id, 0.75):
+        print(f"Opened ticket {clean_ticket} in the existing OpenBoardView window")
+        return 0
+
+    binary = os.environ.get("BOARD_DIAGNOSTICS_BOARDVIEW", "openboardview")
+    command = [binary, "-i", str(board_file), "--ticket", clean_ticket]
+    if target.strip():
+        command.extend(["--locate", target.strip()])
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except OSError as error:
+        raise core.DiagnosticError(f"unable to start OpenBoardView: {error}") from error
+
+    for _attempt in range(25):
+        if wait_for_acknowledgement(request_id, 0.2):
+            break
+        exit_code = process.poll()
+        if exit_code is not None:
+            raise core.DiagnosticError(f"OpenBoardView exited during startup with code {exit_code}")
+
+    print(f"Opened ticket {clean_ticket} in OpenBoardView (pid {process.pid})")
+    return 0
+
+
+def command_create(args: argparse.Namespace) -> int:
+    plan = core.read_plan(args.plan)
+    case, path = core.create_case(
+        args.ticket,
+        args.board,
+        args.issue,
+        plan,
+        workspace=args.workspace,
+        source_plan=args.plan,
+    )
+    print(f"Created ticket {case['ticket']} with round 1")
+    print(f"Case file: {path}")
+    if args.open:
+        return launch_app(case["ticket"])
+    return 0
+
+
+def command_add_round(args: argparse.Namespace) -> int:
+    plan = core.read_plan(args.plan)
+    case, path = core.add_round(args.ticket, plan, source_plan=args.plan)
+    round_data = core.active_round(case)
+    print(f"Added round {round_data['number']} to ticket {case['ticket']}")
+    print(f"Case file: {path}")
+    if args.open:
+        return launch_app(case["ticket"])
+    return 0
+
+
+def command_replace_round(args: argparse.Namespace) -> int:
+    plan = core.read_plan(args.plan)
+    case, path = core.replace_active_round(args.ticket, plan, source_plan=args.plan)
+    round_data = core.active_round(case)
+    print(f"Replaced round {round_data['number']} for ticket {case['ticket']}")
+    print(f"Case file: {path}")
+    if args.open:
+        return launch_app(case["ticket"])
+    return 0
+
+
+def command_results(args: argparse.Namespace) -> int:
+    case = core.load_case(args.ticket)
+    if args.json:
+        print(json.dumps(case, indent=2, ensure_ascii=False))
+    else:
+        print(core.format_results_markdown(case), end="")
+    return 0
+
+
+def status_payload(case: dict) -> dict:
+    round_data = core.active_round(case)
+    return {
+        "ticket": case["ticket"],
+        "case_status": case["status"],
+        "round": round_data["number"],
+        "round_title": round_data["title"],
+        "round_status": round_data["status"],
+        **core.round_progress(round_data),
+    }
+
+
+def command_status(args: argparse.Namespace) -> int:
+    payload = status_payload(core.load_case(args.ticket))
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            f"Ticket {payload['ticket']} · round {payload['round']} · {payload['case_status']} · "
+            f"{payload['measured']}/{payload['total']} checked · {payload['fail']} wrong · "
+            f"{payload['not_measurable']} not measurable · {payload['skipped']} skipped"
+        )
+    return 0
+
+
+def command_list(args: argparse.Namespace) -> int:
+    cases = core.list_cases()
+    if args.json:
+        print(json.dumps(cases, indent=2, ensure_ascii=False))
+        return 0
+    if not cases:
+        print("No board diagnostic tickets yet.")
+        return 0
+    for case in cases:
+        print(
+            f"{case['ticket']}\t{case['status']}\t{case['measured']}/{case['total']}\t"
+            f"{case['board']}\t{case['issue']}"
+        )
+    return 0
+
+
+def command_validate(args: argparse.Namespace) -> int:
+    normalized = core.normalize_plan(core.read_plan(args.plan), args.round)
+    print(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    handlers = {
+        "create": command_create,
+        "add-round": command_add_round,
+        "replace-round": command_replace_round,
+        "open": lambda parsed: launch_app(parsed.ticket, parsed.target),
+        "results": command_results,
+        "status": command_status,
+        "list": command_list,
+        "validate-plan": command_validate,
+    }
+    try:
+        return handlers[args.command](args)
+    except core.DiagnosticError as error:
+        print(f"board-diagnostics: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/board-diagnostics/scripts/board_diagnostics_core.py
+++ b/skills/board-diagnostics/scripts/board_diagnostics_core.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""Storage and validation for ticket-based board diagnostic checklists."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+SCHEMA_VERSION = 1
+TICKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+ALLOWED_MODES = {"voltage", "diode", "resistance", "continuity", "other"}
+UNPOWERED_MODES = {"diode", "resistance", "continuity"}
+UNPOWERED_STATES = {"disconnected", "unpowered", "off"}
+RESULT_STATES = {"untested", "pass", "fail", "not_measurable", "skipped"}
+MEASUREMENT_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+COMPONENT_RE = re.compile(r"\b[A-Za-z]{1,4}\d{2,5}\b")
+
+
+class DiagnosticError(ValueError):
+    """A user-correctable checklist or case error."""
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def normalize_ticket(raw_ticket: str) -> str:
+    ticket = str(raw_ticket or "").strip()
+    if ticket.startswith("#"):
+        ticket = ticket[1:]
+    if not TICKET_RE.fullmatch(ticket):
+        raise DiagnosticError(
+            "ticket must be 1-64 letters, numbers, dots, underscores, or hyphens "
+            "(an optional leading # is accepted)"
+        )
+    return ticket
+
+
+def ticket_slug(ticket: str) -> str:
+    return normalize_ticket(ticket).casefold()
+
+
+def data_root() -> Path:
+    override = os.environ.get("BOARD_DIAGNOSTICS_DATA_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    xdg_data = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg_data).expanduser() if xdg_data else Path.home() / ".local" / "share"
+    return base / "board-diagnostics" / "tickets"
+
+
+def case_path(ticket: str) -> Path:
+    return data_root() / ticket_slug(ticket) / "case.json"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise DiagnosticError(f"ticket not found: {path.parent.name}") from error
+    except json.JSONDecodeError as error:
+        raise DiagnosticError(f"invalid JSON in {path}: {error}") from error
+    except OSError as error:
+        raise DiagnosticError(f"unable to read {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise DiagnosticError(f"{path} must contain a JSON object")
+    return payload
+
+
+def read_plan(path: Path | str) -> dict[str, Any]:
+    plan_path = Path(path).expanduser().resolve()
+    return _read_json(plan_path)
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, path)
+    except OSError as error:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise DiagnosticError(f"unable to save {path}: {error}") from error
+
+
+def _required_text(mapping: dict[str, Any], key: str, location: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise DiagnosticError(f"{location}.{key} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_text(mapping: dict[str, Any], key: str, location: str) -> str:
+    value = mapping.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise DiagnosticError(f"{location}.{key} must be a string")
+    return value.strip()
+
+
+def _slug(value: str, fallback: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+    return slug[:64] or fallback
+
+
+def _unique_id(base: str, used: set[str]) -> str:
+    candidate = base
+    suffix = 2
+    while candidate in used:
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    used.add(candidate)
+    return candidate
+
+
+def normalize_plan(plan: dict[str, Any], round_number: int) -> dict[str, Any]:
+    if not isinstance(plan, dict):
+        raise DiagnosticError("plan must be a JSON object")
+
+    title = _required_text(plan, "title", "plan")
+    summary = _optional_text(plan, "summary", "plan")
+    raw_instructions = plan.get("instructions", [])
+    if not isinstance(raw_instructions, list) or not all(
+        isinstance(item, str) and item.strip() for item in raw_instructions
+    ):
+        raise DiagnosticError("plan.instructions must be an array of non-empty strings")
+
+    raw_sides = plan.get("sides")
+    if not isinstance(raw_sides, list) or len(raw_sides) < 2:
+        raise DiagnosticError("plan.sides must contain at least Side A and Side B")
+
+    normalized_sides: list[dict[str, Any]] = []
+    used_side_ids: set[str] = set()
+    used_measurement_keys: set[str] = set()
+    dependency_records: list[tuple[str, str, list[str]]] = []
+    side_names: list[str] = []
+    measurement_total = 0
+
+    for side_index, raw_side in enumerate(raw_sides):
+        location = f"plan.sides[{side_index}]"
+        if not isinstance(raw_side, dict):
+            raise DiagnosticError(f"{location} must be an object")
+        name = _required_text(raw_side, "name", location)
+        side_names.append(name.casefold())
+        side_id = _unique_id(_slug(name, f"side-{side_index + 1}"), used_side_ids)
+        raw_sections = raw_side.get("sections", [])
+        if not isinstance(raw_sections, list):
+            raise DiagnosticError(f"{location}.sections must be an array")
+
+        sections: list[dict[str, Any]] = []
+        used_section_ids: set[str] = set()
+        for section_index, raw_section in enumerate(raw_sections):
+            section_location = f"{location}.sections[{section_index}]"
+            if not isinstance(raw_section, dict):
+                raise DiagnosticError(f"{section_location} must be an object")
+            section_title = _required_text(raw_section, "title", section_location)
+            mode = _required_text(raw_section, "mode", section_location).casefold()
+            if mode not in ALLOWED_MODES:
+                allowed = ", ".join(sorted(ALLOWED_MODES))
+                raise DiagnosticError(f"{section_location}.mode must be one of: {allowed}")
+            power_state = _required_text(raw_section, "power_state", section_location).casefold()
+            if mode in UNPOWERED_MODES and power_state not in UNPOWERED_STATES:
+                raise DiagnosticError(
+                    f"{section_location} uses {mode} mode but power_state is {power_state!r}; "
+                    "use disconnected, unpowered, or off"
+                )
+            safety = _optional_text(raw_section, "safety", section_location)
+            raw_measurements = raw_section.get("measurements", [])
+            if not isinstance(raw_measurements, list):
+                raise DiagnosticError(f"{section_location}.measurements must be an array")
+
+            measurements: list[dict[str, Any]] = []
+            used_measurement_ids: set[str] = set()
+            for measurement_index, raw_measurement in enumerate(raw_measurements):
+                measurement_location = (
+                    f"{section_location}.measurements[{measurement_index}]"
+                )
+                if not isinstance(raw_measurement, dict):
+                    raise DiagnosticError(f"{measurement_location} must be an object")
+                point = _required_text(raw_measurement, "point", measurement_location)
+                reference = _required_text(raw_measurement, "reference", measurement_location)
+                expected = _required_text(raw_measurement, "expected", measurement_location)
+                raw_key = _optional_text(raw_measurement, "key", measurement_location)
+                if raw_key:
+                    if not MEASUREMENT_KEY_RE.fullmatch(raw_key):
+                        raise DiagnosticError(
+                            f"{measurement_location}.key must be 1-64 letters, numbers, "
+                            "dots, underscores, or hyphens"
+                        )
+                    if raw_key in used_measurement_keys:
+                        raise DiagnosticError(f"duplicate measurement key: {raw_key}")
+                    used_measurement_keys.add(raw_key)
+                    measurement_key = raw_key
+                else:
+                    measurement_key = _unique_id(
+                        _slug(
+                            f"{section_title}-{point}-{reference}",
+                            f"measurement-{measurement_total + 1}",
+                        ),
+                        used_measurement_keys,
+                    )
+
+                raw_requires = raw_measurement.get("requires_pass", [])
+                if not isinstance(raw_requires, list) or not all(
+                    isinstance(item, str) and item.strip() for item in raw_requires
+                ):
+                    raise DiagnosticError(
+                        f"{measurement_location}.requires_pass must be an array of "
+                        "non-empty measurement keys"
+                    )
+                requires_pass = [item.strip() for item in raw_requires]
+                if len(requires_pass) != len(set(requires_pass)):
+                    raise DiagnosticError(
+                        f"{measurement_location}.requires_pass contains duplicate keys"
+                    )
+
+                boardview = _optional_text(raw_measurement, "boardview", measurement_location)
+                if not boardview:
+                    component_match = COMPONENT_RE.search(point)
+                    boardview = component_match.group(0) if component_match else ""
+                measurement_id = _unique_id(
+                    _slug(f"{point}-{reference}", f"measurement-{measurement_index + 1}"),
+                    used_measurement_ids,
+                )
+                measurements.append(
+                    {
+                        "id": measurement_id,
+                        "key": measurement_key,
+                        "point": point,
+                        "reference": reference,
+                        "expected": expected,
+                        "probe": _optional_text(raw_measurement, "probe", measurement_location),
+                        "location": _optional_text(raw_measurement, "location", measurement_location),
+                        "why": _optional_text(raw_measurement, "why", measurement_location),
+                        "boardview": boardview,
+                        "requires_pass": requires_pass,
+                        # Seed the editable field with the expected result. The row remains
+                        # untested until the technician explicitly marks its status.
+                        "actual": expected,
+                        "status": "untested",
+                        "auto_skipped": False,
+                        "note": "",
+                    }
+                )
+                dependency_records.append(
+                    (measurement_location, measurement_key, requires_pass)
+                )
+                measurement_total += 1
+
+            section_id = _unique_id(
+                _slug(section_title, f"section-{section_index + 1}"), used_section_ids
+            )
+            sections.append(
+                {
+                    "id": section_id,
+                    "title": section_title,
+                    "mode": mode,
+                    "power_state": power_state,
+                    "safety": safety,
+                    "measurements": measurements,
+                }
+            )
+
+        normalized_sides.append(
+            {
+                "id": side_id,
+                "name": name,
+                "comments": "",
+                "sections": sections,
+            }
+        )
+
+    if not any(name.startswith("side a") for name in side_names) or not any(
+        name.startswith("side b") for name in side_names
+    ):
+        raise DiagnosticError("plan must include tabs named Side A and Side B")
+    if measurement_total == 0:
+        raise DiagnosticError("plan must contain at least one measurement")
+
+    dependency_graph: dict[str, list[str]] = {}
+    for location, measurement_key, requires_pass in dependency_records:
+        for required_key in requires_pass:
+            if required_key not in used_measurement_keys:
+                raise DiagnosticError(
+                    f"{location}.requires_pass references unknown key: {required_key}"
+                )
+            if required_key == measurement_key:
+                raise DiagnosticError(f"{location} cannot depend on itself")
+        dependency_graph[measurement_key] = requires_pass
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(measurement_key: str) -> None:
+        if measurement_key in visiting:
+            raise DiagnosticError("measurement dependencies contain a cycle")
+        if measurement_key in visited:
+            return
+        visiting.add(measurement_key)
+        for required_key in dependency_graph.get(measurement_key, []):
+            visit(required_key)
+        visiting.remove(measurement_key)
+        visited.add(measurement_key)
+
+    for measurement_key in dependency_graph:
+        visit(measurement_key)
+
+    timestamp = now_utc()
+    return {
+        "id": f"round-{round_number}",
+        "number": round_number,
+        "title": title,
+        "summary": summary,
+        "instructions": [item.strip() for item in raw_instructions],
+        "status": "in_progress",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "completed_at": None,
+        "sides": normalized_sides,
+    }
+
+
+def create_case(
+    ticket: str,
+    board: str,
+    issue: str,
+    plan: dict[str, Any],
+    *,
+    workspace: Path | str,
+    source_plan: Path | str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    clean_ticket = normalize_ticket(ticket)
+    path = case_path(clean_ticket)
+    if path.exists():
+        raise DiagnosticError(
+            f"ticket {clean_ticket} already exists; add a follow-up round instead of replacing it"
+        )
+    board_name = str(board or "").strip()
+    issue_text = str(issue or "").strip()
+    if not board_name:
+        raise DiagnosticError("board must be a non-empty string")
+    if not issue_text:
+        raise DiagnosticError("issue must be a non-empty string")
+    workspace_path = Path(workspace).expanduser().resolve()
+    if not workspace_path.is_dir():
+        raise DiagnosticError(f"workspace is not a directory: {workspace_path}")
+
+    first_round = normalize_plan(plan, 1)
+    timestamp = now_utc()
+    case: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "ticket": clean_ticket,
+        "board": board_name,
+        "issue": issue_text,
+        "status": "in_progress",
+        "source_workspace": str(workspace_path),
+        "source_plan": str(Path(source_plan).expanduser().resolve()) if source_plan else "",
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "active_round_id": first_round["id"],
+        "rounds": [first_round],
+    }
+    atomic_write_json(path, case)
+    return case, path
+
+
+def load_case(ticket: str) -> dict[str, Any]:
+    clean_ticket = normalize_ticket(ticket)
+    path = case_path(clean_ticket)
+    case = _read_json(path)
+    if case.get("schema_version") != SCHEMA_VERSION:
+        raise DiagnosticError(
+            f"ticket {clean_ticket} uses unsupported schema version {case.get('schema_version')!r}"
+        )
+    if str(case.get("ticket", "")).casefold() != clean_ticket.casefold():
+        raise DiagnosticError(f"ticket data mismatch in {path}")
+    if not isinstance(case.get("rounds"), list):
+        raise DiagnosticError(f"ticket {clean_ticket} has an invalid rounds list")
+    return case
+
+
+def save_case(case: dict[str, Any]) -> Path:
+    ticket = normalize_ticket(str(case.get("ticket", "")))
+    case["updated_at"] = now_utc()
+    path = case_path(ticket)
+    atomic_write_json(path, case)
+    return path
+
+
+def active_round(case: dict[str, Any]) -> dict[str, Any]:
+    active_id = case.get("active_round_id")
+    for round_data in case.get("rounds", []):
+        if isinstance(round_data, dict) and round_data.get("id") == active_id:
+            return round_data
+    raise DiagnosticError(f"ticket {case.get('ticket', '?')} has no active round")
+
+
+def add_round(
+    ticket: str,
+    plan: dict[str, Any],
+    *,
+    source_plan: Path | str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    case = load_case(ticket)
+    current = active_round(case)
+    if current.get("status") != "complete":
+        raise DiagnosticError(
+            f"ticket {case['ticket']} still has an unfinished active round; finish it before adding another"
+        )
+    round_number = len(case["rounds"]) + 1
+    next_round = normalize_plan(plan, round_number)
+    case["rounds"].append(next_round)
+    case["active_round_id"] = next_round["id"]
+    case["status"] = "in_progress"
+    if source_plan:
+        case["source_plan"] = str(Path(source_plan).expanduser().resolve())
+    return case, save_case(case)
+
+
+def replace_active_round(
+    ticket: str,
+    plan: dict[str, Any],
+    *,
+    source_plan: Path | str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    """Replace an unfinished round that has no recorded technician decisions."""
+    case = load_case(ticket)
+    current = active_round(case)
+    if current.get("status") == "complete":
+        raise DiagnosticError("cannot replace a completed round")
+
+    for side in current.get("sides", []):
+        if str(side.get("comments", "")).strip():
+            raise DiagnosticError("cannot replace a round with recorded comments")
+        for section in side.get("sections", []):
+            for measurement in section.get("measurements", []):
+                if measurement.get("status", "untested") != "untested":
+                    raise DiagnosticError("cannot replace a round with recorded results")
+                actual = str(measurement.get("actual", "")).strip()
+                expected = str(measurement.get("expected", "")).strip()
+                if actual and actual != expected:
+                    raise DiagnosticError("cannot replace a round with edited readings")
+                if str(measurement.get("note", "")).strip():
+                    raise DiagnosticError("cannot replace a round with recorded notes")
+
+    replacement = normalize_plan(plan, int(current.get("number", 1)))
+    for index, round_data in enumerate(case.get("rounds", [])):
+        if round_data.get("id") == current.get("id"):
+            case["rounds"][index] = replacement
+            break
+    else:
+        raise DiagnosticError("active round was not found in the ticket")
+
+    case["active_round_id"] = replacement["id"]
+    case["status"] = "in_progress"
+    if source_plan:
+        case["source_plan"] = str(Path(source_plan).expanduser().resolve())
+    return case, save_case(case)
+
+
+def iter_measurements(round_data: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    for side in round_data.get("sides", []):
+        for section in side.get("sections", []):
+            yield from section.get("measurements", [])
+
+
+def measurements_by_key(round_data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(measurement.get("key", measurement.get("id", ""))): measurement
+        for measurement in iter_measurements(round_data)
+    }
+
+
+def dependency_state(round_data: dict[str, Any], measurement: dict[str, Any]) -> str:
+    """Return ready, pending, or skipped for a conditional measurement."""
+    required_keys = measurement.get("requires_pass", [])
+    if not required_keys:
+        return "ready"
+    by_key = measurements_by_key(round_data)
+    statuses = [by_key[key].get("status", "untested") for key in required_keys if key in by_key]
+    if len(statuses) != len(required_keys):
+        return "pending"
+    if any(status in {"fail", "not_measurable", "skipped"} for status in statuses):
+        return "skipped"
+    if all(status == "pass" for status in statuses):
+        return "ready"
+    return "pending"
+
+
+def apply_dependencies(round_data: dict[str, Any]) -> bool:
+    """Propagate automatic skips without overwriting measurements already performed."""
+    changed = False
+    made_change = True
+    while made_change:
+        made_change = False
+        for measurement in iter_measurements(round_data):
+            state = dependency_state(round_data, measurement)
+            status = measurement.get("status", "untested")
+            auto_skipped = bool(measurement.get("auto_skipped", False))
+            if state == "skipped" and status in {"untested", "skipped"}:
+                if status != "skipped" or not auto_skipped:
+                    measurement["status"] = "skipped"
+                    measurement["auto_skipped"] = True
+                    changed = made_change = True
+            elif state != "skipped" and auto_skipped:
+                measurement["status"] = "untested"
+                measurement["auto_skipped"] = False
+                changed = made_change = True
+    return changed
+
+
+def round_progress(round_data: dict[str, Any]) -> dict[str, int]:
+    counts = {state: 0 for state in RESULT_STATES}
+    for measurement in iter_measurements(round_data):
+        status = measurement.get("status", "untested")
+        counts[status if status in RESULT_STATES else "untested"] += 1
+    counts["total"] = sum(counts.values())
+    counts["measured"] = counts["total"] - counts["untested"]
+    return counts
+
+
+def _mark_edited(case: dict[str, Any], round_data: dict[str, Any]) -> None:
+    timestamp = now_utc()
+    round_data["updated_at"] = timestamp
+    if round_data.get("status") == "complete":
+        round_data["status"] = "in_progress"
+        round_data["completed_at"] = None
+        case["status"] = "in_progress"
+
+
+def update_measurement(
+    case: dict[str, Any],
+    round_id: str,
+    side_id: str,
+    section_id: str,
+    measurement_id: str,
+    *,
+    actual: str | None = None,
+    status: str | None = None,
+    note: str | None = None,
+) -> Path:
+    if status is not None and status not in RESULT_STATES:
+        raise DiagnosticError(f"invalid measurement status: {status}")
+    for round_data in case.get("rounds", []):
+        if round_data.get("id") != round_id:
+            continue
+        for side in round_data.get("sides", []):
+            if side.get("id") != side_id:
+                continue
+            for section in side.get("sections", []):
+                if section.get("id") != section_id:
+                    continue
+                for measurement in section.get("measurements", []):
+                    if measurement.get("id") != measurement_id:
+                        continue
+                    if actual is not None:
+                        measurement["actual"] = str(actual).strip()
+                    if status is not None:
+                        measurement["status"] = status
+                        measurement["auto_skipped"] = False
+                    if note is not None:
+                        measurement["note"] = str(note).strip()
+                    apply_dependencies(round_data)
+                    _mark_edited(case, round_data)
+                    return save_case(case)
+    raise DiagnosticError(f"measurement not found: {measurement_id}")
+
+
+def update_side_comments(
+    case: dict[str, Any], round_id: str, side_id: str, comments: str
+) -> Path:
+    for round_data in case.get("rounds", []):
+        if round_data.get("id") != round_id:
+            continue
+        for side in round_data.get("sides", []):
+            if side.get("id") == side_id:
+                side["comments"] = str(comments).strip()
+                _mark_edited(case, round_data)
+                return save_case(case)
+    raise DiagnosticError(f"side not found: {side_id}")
+
+
+def finish_active_round(case: dict[str, Any]) -> Path:
+    round_data = active_round(case)
+    timestamp = now_utc()
+    round_data["status"] = "complete"
+    round_data["updated_at"] = timestamp
+    round_data["completed_at"] = timestamp
+    case["status"] = "waiting_for_ai"
+    return save_case(case)
+
+
+def _natural_key(value: str) -> list[Any]:
+    return [int(part) if part.isdigit() else part.casefold() for part in re.split(r"(\d+)", value)]
+
+
+def list_cases() -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    root = data_root()
+    if not root.exists():
+        return cases
+    for path in root.glob("*/case.json"):
+        try:
+            case = _read_json(path)
+            latest = active_round(case)
+            progress = round_progress(latest)
+            cases.append(
+                {
+                    "ticket": str(case.get("ticket", path.parent.name)),
+                    "board": str(case.get("board", "")),
+                    "issue": str(case.get("issue", "")),
+                    "status": str(case.get("status", "unknown")),
+                    "round": latest.get("number"),
+                    "measured": progress["measured"],
+                    "total": progress["total"],
+                    "updated_at": case.get("updated_at"),
+                    "path": str(path),
+                }
+            )
+        except DiagnosticError:
+            continue
+    return sorted(cases, key=lambda item: _natural_key(item["ticket"]))
+
+
+def format_results_markdown(case: dict[str, Any]) -> str:
+    lines = [
+        f"# Ticket {case['ticket']} — {case['board']}",
+        "",
+        f"Issue: {case['issue']}",
+        f"Case status: {case['status']}",
+    ]
+    status_labels = {
+        "untested": "○ UNTESTED",
+        "pass": "✓ RIGHT",
+        "fail": "✕ WRONG",
+        "not_measurable": "— NOT MEASURABLE",
+        "skipped": "↷ SKIPPED",
+    }
+    for round_data in case.get("rounds", []):
+        progress = round_progress(round_data)
+        lines.extend(
+            [
+                "",
+                f"## Round {round_data.get('number')} — {round_data.get('title')}",
+                "",
+                f"Round status: {round_data.get('status')} · "
+                f"{progress['measured']}/{progress['total']} checked · "
+                f"{progress['fail']} wrong · {progress['not_measurable']} not measurable · "
+                f"{progress['skipped']} skipped",
+            ]
+        )
+        summary = str(round_data.get("summary", "")).strip()
+        if summary:
+            lines.extend(["", summary])
+        for side in round_data.get("sides", []):
+            lines.extend(["", f"### {side.get('name')}"])
+            for section in side.get("sections", []):
+                lines.extend(
+                    [
+                        "",
+                        f"#### {section.get('title')} "
+                        f"[{section.get('mode')} · power {section.get('power_state')}]",
+                    ]
+                )
+                for measurement in section.get("measurements", []):
+                    status = measurement.get("status", "untested")
+                    label = status_labels.get(status, status.upper())
+                    actual = str(measurement.get("actual", "")).strip() or "—"
+                    note = str(measurement.get("note", "")).strip()
+                    detail = (
+                        f"- {label} · {measurement.get('point')} → "
+                        f"{measurement.get('reference')} · expected {measurement.get('expected')} · "
+                        f"actual {actual}"
+                    )
+                    if note:
+                        detail += f" · note: {note}"
+                    lines.append(detail)
+            comments = str(side.get("comments", "")).strip()
+            if comments:
+                lines.extend(["", f"Comments: {comments}"])
+    return "\n".join(lines) + "\n"

--- a/src/openboardview/AgentSkillInstaller.cpp
+++ b/src/openboardview/AgentSkillInstaller.cpp
@@ -1,0 +1,115 @@
+#include "AgentSkillInstaller.h"
+
+#include "filesystem_impl.h"
+
+#include <SDL.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace {
+
+filesystem::path user_home() {
+	if (const char *override_path = std::getenv("OPENBOARDVIEW_AGENT_HOME")) {
+		if (*override_path) return filesystem::u8path(override_path);
+	}
+	const char *home = std::getenv("HOME");
+#ifdef _WIN32
+	if (!home || !*home) home = std::getenv("USERPROFILE");
+#endif
+	return home && *home ? filesystem::u8path(home) : filesystem::path{};
+}
+
+filesystem::path bundled_skill() {
+	if (const char *override_path = std::getenv("OPENBOARDVIEW_SKILL_DIR")) {
+		if (*override_path) return filesystem::u8path(override_path);
+	}
+
+	char *raw_base = SDL_GetBasePath();
+	if (!raw_base) return {};
+	const filesystem::path base = filesystem::u8path(raw_base);
+	SDL_free(raw_base);
+#ifdef __APPLE__
+	return base / ".." / "Resources" / "openboardview" / "skills" / "board-diagnostics";
+#else
+	return base / ".." / "share" / "openboardview" / "skills" / "board-diagnostics";
+#endif
+}
+
+bool files_equal(const filesystem::path &left, const filesystem::path &right) {
+	std::error_code error;
+	if (!filesystem::is_regular_file(right, error) || error) return false;
+	const auto left_size = filesystem::file_size(left, error);
+	if (error) return false;
+	const auto right_size = filesystem::file_size(right, error);
+	if (error || left_size != right_size) return false;
+
+	ifstream left_stream(left, std::ios::binary);
+	ifstream right_stream(right, std::ios::binary);
+	return left_stream && right_stream &&
+	       std::equal(std::istreambuf_iterator<char>(left_stream),
+	                  std::istreambuf_iterator<char>(),
+	                  std::istreambuf_iterator<char>(right_stream));
+}
+
+bool sync_file(const filesystem::path &source, const filesystem::path &destination) {
+	if (files_equal(source, destination)) return true;
+	std::error_code error;
+	filesystem::create_directories(destination.parent_path(), error);
+	if (error) return false;
+	filesystem::copy_file(source, destination, filesystem::copy_options::overwrite_existing, error);
+	return !error;
+}
+
+void sync_skill(const filesystem::path &source, const filesystem::path &destination) {
+	static const std::vector<filesystem::path> files = {
+	    "SKILL.md",
+	    filesystem::path("references") / "checklist-plan.md",
+	    filesystem::path("scripts") / "board_diagnostics.py",
+	    filesystem::path("scripts") / "board_diagnostics_core.py",
+	};
+
+	std::error_code error;
+	const bool destination_exists = filesystem::exists(destination, error);
+	const filesystem::path marker = destination / ".openboardview-managed";
+	if (error || (destination_exists && !filesystem::exists(marker, error))) {
+		SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+		            "Board Diagnostics skill already exists and is not managed by OpenBoardView: %s",
+		            destination.string().c_str());
+		return;
+	}
+
+	filesystem::create_directories(destination, error);
+	if (error) return;
+	if (!filesystem::exists(marker, error)) {
+		ofstream marker_stream(marker);
+		marker_stream << "Installed and updated by OpenBoardView.\n";
+		if (!marker_stream) return;
+	}
+
+	for (const auto &relative : files) {
+		if (!sync_file(source / relative, destination / relative)) {
+			SDL_LogWarn(
+			    SDL_LOG_CATEGORY_APPLICATION, "Unable to install Board Diagnostics skill file: %s", relative.string().c_str());
+			return;
+		}
+	}
+}
+
+} // namespace
+
+void InstallBundledBoardDiagnosticsSkill() {
+	const filesystem::path source = bundled_skill();
+	const filesystem::path home   = user_home();
+	std::error_code error;
+	if (home.empty() || !filesystem::is_regular_file(source / "SKILL.md", error) || error) return;
+
+	// Codex and OpenCode both discover ~/.agents/skills. Claude Code uses ~/.claude/skills.
+	sync_skill(source, home / ".agents" / "skills" / "board-diagnostics");
+	sync_skill(source, home / ".claude" / "skills" / "board-diagnostics");
+}

--- a/src/openboardview/AgentSkillInstaller.h
+++ b/src/openboardview/AgentSkillInstaller.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void InstallBundledBoardDiagnosticsSkill();

--- a/src/openboardview/BoardView.cpp
+++ b/src/openboardview/BoardView.cpp
@@ -175,6 +175,15 @@ int BoardView::LoadFile(const filesystem::path &filepath) {
 				m_lastFileOpenWasInvalid = false;
 				m_validBoard             = true;
 				m_error_msg.clear();
+#ifdef ENABLE_DIAGNOSTICS
+				diagnostics.SetBoardFile(filepath);
+				if (diagnostics.HasCase()) {
+					config.showInfoPanel = true;
+					m_sidePanelMode = 1;
+					m_diagnosticsWidthExpanded = false;
+					m_diagnosticsWidthManuallySized = false;
+				}
+#endif
 			}
 		}
 	} else {
@@ -190,6 +199,21 @@ void BoardView::ShowInfoPane(void) {
 	ImVec2 ds   = io.DisplaySize;
 
 	if (!config.showInfoPanel) return;
+#ifdef ENABLE_DIAGNOSTICS
+	const bool diagnostics_open = diagnostics.HasCase() && m_sidePanelMode == 1;
+	const bool display_width_changed = std::abs(ds.x - m_lastDiagnosticsDisplayWidth) > DPIF(24.0f);
+	if (diagnostics_open && !m_diagnosticsWidthManuallySized && (!m_diagnosticsWidthExpanded || display_width_changed)) {
+		const float preferred_width = std::max(DPIF(228.0f), std::min(DPIF(408.0f), ds.x * 0.276f));
+		const float maximum_width = std::max(DPIF(156.0f), ds.x - DPIF(320.0f));
+		m_info_surface.x = std::min(preferred_width, maximum_width);
+		m_board_surface.x = ds.x - m_info_surface.x;
+		m_diagnosticsWidthExpanded = true;
+		m_needsRedraw = true;
+	}
+	m_lastDiagnosticsDisplayWidth = ds.x;
+#else
+	const bool diagnostics_open = false;
+#endif
 
 	if (m_info_surface.x < DPIF(100)) {
 		//	fprintf(stderr,"Too small (%f), set to (%f)\n", width, DPIF(100));
@@ -213,6 +237,8 @@ void BoardView::ShowInfoPane(void) {
 	             NULL,
 	             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
 	                 ImGuiWindowFlags_NoSavedSettings);
+	if (diagnostics_open) ImGui::SetWindowFontScale(1.10f);
+	else ImGui::SetWindowFontScale(1.0f);
 
 	if ((m_dragging_token == 0) && (io.MousePos.x > m_board_surface.x) && (io.MousePos.x < (m_board_surface.x + DPIF(12.0f)))) {
 		ImDrawList *draw = ImGui::GetWindowDrawList();
@@ -236,19 +262,53 @@ void BoardView::ShowInfoPane(void) {
 			ImGui::ResetMouseDragDelta();
 			m_board_surface.x += delta.x;
 			m_info_surface.x = ds.x - m_board_surface.x;
-			if (m_board_surface.x < ds.x * 0.66) {
-				m_board_surface.x = ds.x * 0.66;
+			const float minimum_board_ratio = diagnostics_open ? 0.50f : 0.66f;
+			if (m_board_surface.x < ds.x * minimum_board_ratio) {
+				m_board_surface.x = ds.x * minimum_board_ratio;
 				m_info_surface.x  = ds.x - m_board_surface.x;
 			}
 			if (delta.x > 0) m_needsRedraw = true;
 		}
 	} else {
 		if (m_dragging_token == 2) {
+#ifdef ENABLE_DIAGNOSTICS
+			if (diagnostics_open) m_diagnosticsWidthManuallySized = true;
+#endif
 			config.infoPanelWidth = IDPIF(m_info_surface.x); // Convert back to DPI-independant value
 			obvconfig.WriteInt("infoPanelWidth", config.infoPanelWidth);
 		}
 		m_dragging_token = 0;
 	}
+
+#ifdef ENABLE_DIAGNOSTICS
+	if (diagnostics.HasCase()) {
+		const ImGuiStyle &style = ImGui::GetStyle();
+		const float tab_width = (ImGui::GetContentRegionAvail().x - style.ItemSpacing.x) * 0.5f;
+		auto panel_tab = [&](const char *label, int mode) {
+			const bool active = m_sidePanelMode == mode;
+			ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[active ? ImGuiCol_TabSelected : ImGuiCol_Tab]);
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, style.Colors[ImGuiCol_TabHovered]);
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, style.Colors[ImGuiCol_TabSelected]);
+			if (ImGui::Button(label, ImVec2(tab_width, 0.0f))) {
+				m_sidePanelMode = mode;
+				m_needsRedraw = true;
+			}
+			ImGui::PopStyleColor(3);
+		};
+		panel_tab("Board", 0);
+		ImGui::SameLine();
+		panel_tab("Diagnostics", 1);
+		ImGui::Separator();
+		if (m_sidePanelMode == 1) {
+			diagnostics.Draw([this](const std::string &target, bool show_context, std::string &error) {
+				return LocateDiagnosticTarget(target, show_context, error);
+			});
+			ImGui::End();
+			ImGui::PopStyleVar();
+			return;
+		}
+	}
+#endif
 
 	if (m_board) {
 		ImGui::Columns(2);
@@ -3538,6 +3598,75 @@ void BoardView::SearchCompound(const char *item) {
 void BoardView::SetLastFileOpenName(const std::string &name) {
 	m_lastFileOpenName = name;
 }
+
+#ifdef ENABLE_DIAGNOSTICS
+void BoardView::SetDiagnosticTicket(const std::string &ticket) {
+	diagnostics.SetPreferredTicket(ticket);
+}
+
+void BoardView::SetDiagnosticTarget(const std::string &target) {
+	diagnostics.SetPendingTarget(target);
+}
+
+bool BoardView::PollDiagnostics() {
+	const bool changed = diagnostics.PollForChanges();
+	if (changed && diagnostics.HasCase()) {
+		config.showInfoPanel = true;
+		m_sidePanelMode = 1;
+		m_needsRedraw = true;
+	}
+	const std::string target = diagnostics.TakePendingTarget();
+	if (!target.empty() && m_validBoard) {
+		std::string error;
+		LocateDiagnosticTarget(target, false, error);
+		return true;
+	}
+	return changed;
+}
+
+bool BoardView::LocateDiagnosticTarget(const std::string &target, bool show_context, std::string &error) {
+	if (!m_validBoard || !m_board) {
+		error = "Load the ticket's board file before locating a measurement.";
+		return false;
+	}
+	auto center_target = [&]() {
+		const bool previous_center_zoom = config.centerZoomSearchResults;
+		const float previous_zoom_factor = config.partZoomScaleOutFactor;
+		config.centerZoomSearchResults = true;
+		if (show_context) config.partZoomScaleOutFactor *= 5.0f;
+		CenterZoomSearchResults();
+		config.centerZoomSearchResults = previous_center_zoom;
+		config.partZoomScaleOutFactor = previous_zoom_factor;
+	};
+
+	ClearAllHighlights();
+	for (const auto &part : m_board->Components()) {
+		if (stricmp(part->name.c_str(), target.c_str()) != 0) continue;
+		m_partHighlighted.push_back(part);
+		for (const auto &pin : part->pins) m_pinHighlighted.push_back(pin);
+		if (!BoardElementIsVisible(part)) FlipBoard(1);
+		center_target();
+		m_needsRedraw = true;
+		return true;
+	}
+
+	for (const auto &net : m_board->Nets()) {
+		if (stricmp(net->name.c_str(), target.c_str()) != 0) continue;
+		bool visible = false;
+		for (const auto &pin : net->pins) {
+			m_pinHighlighted.push_back(pin);
+			visible |= BoardElementIsVisible(pin->component);
+		}
+		if (!visible && !net->pins.empty()) FlipBoard(1);
+		center_target();
+		m_needsRedraw = true;
+		return true;
+	}
+
+	error = "No component or net named " + target + " exists in this boardview.";
+	return false;
+}
+#endif
 
 void BoardView::FlipBoard(int mode) {
 	ImVec2 mpos = ImGui::GetMousePos();

--- a/src/openboardview/BoardView.h
+++ b/src/openboardview/BoardView.h
@@ -4,6 +4,9 @@
 #include "Searcher.h"
 #include "SpellCorrector.h"
 #include "Annotations.h"
+#ifdef ENABLE_DIAGNOSTICS
+#include "DiagnosticsPanel.h"
+#endif
 #include "confparse.h"
 #include "history.h"
 #include "imgui/imgui.h"
@@ -105,6 +108,9 @@ struct BoardView {
 
 	/* Context menu, sql stuff */
 	Annotations m_annotations;
+#ifdef ENABLE_DIAGNOSTICS
+	DiagnosticsPanel diagnostics;
+#endif
 	void ContextMenu(void);
 	int AnnotationIsHovered(void);
 	bool AnnotationWasHovered     = false;
@@ -180,6 +186,12 @@ struct BoardView {
 	bool m_showPartList;
 	bool m_showPreferences;
 	bool m_showColorPreferences;
+#ifdef ENABLE_DIAGNOSTICS
+	int m_sidePanelMode = 0;
+	bool m_diagnosticsWidthExpanded = false;
+	bool m_diagnosticsWidthManuallySized = false;
+	float m_lastDiagnosticsDisplayWidth = 0.0f;
+#endif
 	bool m_firstFrame = true;
 	bool m_lastFileOpenWasInvalid;
 	bool m_validBoard = false;
@@ -239,6 +251,12 @@ struct BoardView {
 	std::pair<SharedVector<Component>, SharedVector<Net>> SearchPartsAndNets(const char *search, int limit);
 
 	void SetLastFileOpenName(const std::string &name);
+#ifdef ENABLE_DIAGNOSTICS
+	void SetDiagnosticTicket(const std::string &ticket);
+	void SetDiagnosticTarget(const std::string &target);
+	bool PollDiagnostics();
+	bool LocateDiagnosticTarget(const std::string &target, bool show_context, std::string &error);
+#endif
 	void FlipBoard(int mode = 0);
 	void HandlePDFBridgeSelection();
 };

--- a/src/openboardview/CMakeLists.txt
+++ b/src/openboardview/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(ENABLE_BOARD_DIAGNOSTICS "Build the optional ticket-based diagnostics panel" ON)
+
 if(ENABLE_GL1)
 	add_definitions(-DENABLE_GL1)
 endif()
@@ -50,6 +52,31 @@ else()
 	endif(APPLE)
 endif()
 
+if(ENABLE_BOARD_DIAGNOSTICS)
+	find_package(PkgConfig QUIET)
+	if(PKG_CONFIG_FOUND)
+		pkg_check_modules(JSONC json-c)
+	endif()
+	if(JSONC_FOUND)
+		message(STATUS "Found json-c version ${JSONC_VERSION}; enabling diagnostics panel")
+		link_directories(${JSONC_LIBRARY_DIRS})
+		add_definitions(${JSONC_CFLAGS} ${JSONC_CFLAGS_OTHER})
+		add_definitions(-DENABLE_DIAGNOSTICS)
+		set(DIAGNOSTICS_SOURCES DiagnosticsPanel.cpp AgentSkillInstaller.cpp)
+		if(APPLE)
+			set(DIAGNOSTICS_SKILL_DESTINATION "openboardview.app/Contents/Resources/openboardview/skills")
+		else()
+			set(DIAGNOSTICS_SKILL_DESTINATION "share/openboardview/skills")
+		endif()
+		install(DIRECTORY "${PROJECT_SOURCE_DIR}/skills/board-diagnostics"
+		        DESTINATION "${DIAGNOSTICS_SKILL_DESTINATION}"
+		        PATTERN "__pycache__" EXCLUDE
+		        PATTERN "*.pyc" EXCLUDE)
+	else()
+		message(STATUS "json-c not found; diagnostics panel will not be built")
+	endif()
+endif()
+
 # python is required for GenCAD grammar build-rime generation
 if (CMAKE_VERSION VERSION_GREATER 3.12)
 	find_package(Python REQUIRED COMPONENTS Interpreter)
@@ -65,6 +92,7 @@ set(SOURCES
 	history.cpp
 	utils.cpp
 	Annotations.cpp
+	${DIAGNOSTICS_SOURCES}
 	BoardView.cpp
 	Board.cpp
 	BRDBoard.cpp
@@ -196,6 +224,7 @@ target_include_directories(${PROJECT_NAME_LOWER} PRIVATE
 	${OPENGL_INCLUDE_DIR}
 	${ZLIB_INCLUDE_DIRS}
 	${FONTCONFIG_INCLUDE_DIRS}
+	${JSONC_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME_LOWER}
@@ -207,6 +236,7 @@ target_link_libraries(${PROJECT_NAME_LOWER}
 	${ZLIB_LIBRARIES}
 	${FILESYSTEM_LIBRARIES}
 	${CMAKE_DL_LIBS}
+	${JSONC_LIBRARIES}
 )
 
 if(NOT APPLE AND NOT MINGW)

--- a/src/openboardview/DiagnosticsPanel.cpp
+++ b/src/openboardview/DiagnosticsPanel.cpp
@@ -1,0 +1,744 @@
+#include "DiagnosticsPanel.h"
+
+#include "imgui/imgui.h"
+#include "imgui/misc/cpp/imgui_stdlib.h"
+
+#include <json-c/json.h>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <system_error>
+#include <unordered_map>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+json_object *field(json_object *object, const char *name) {
+	json_object *value = nullptr;
+	if (!object || !json_object_is_type(object, json_type_object)) return nullptr;
+	return json_object_object_get_ex(object, name, &value) ? value : nullptr;
+}
+
+std::string text_field(json_object *object, const char *name) {
+	json_object *value = field(object, name);
+	if (!value || !json_object_is_type(value, json_type_string)) return {};
+	const char *text = json_object_get_string(value);
+	return text ? text : "";
+}
+
+bool bool_field(json_object *object, const char *name, bool fallback = false) {
+	json_object *value = field(object, name);
+	return value ? json_object_get_boolean(value) != 0 : fallback;
+}
+
+void set_text(json_object *object, const char *name, const std::string &value) {
+	json_object_object_add(object, name, json_object_new_string(value.c_str()));
+}
+
+void set_bool(json_object *object, const char *name, bool value) {
+	json_object_object_add(object, name, json_object_new_boolean(value));
+}
+
+std::string lowercase(std::string value) {
+	std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+	return value;
+}
+
+std::string timestamp_utc() {
+	const std::time_t now = std::time(nullptr);
+	std::tm utc{};
+#ifdef _WIN32
+	gmtime_s(&utc, &now);
+#else
+	gmtime_r(&now, &utc);
+#endif
+	std::ostringstream output;
+	output << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+	return output.str();
+}
+
+filesystem::path normalized_path(const filesystem::path &path) {
+	if (path.empty()) return {};
+	std::error_code error;
+	auto normalized = filesystem::weakly_canonical(path, error);
+	return error ? path.lexically_normal() : normalized;
+}
+
+bool path_is_within(const filesystem::path &path, const filesystem::path &directory) {
+	const auto child = normalized_path(path);
+	const auto parent = normalized_path(directory);
+	if (child.empty() || parent.empty()) return false;
+	auto child_it = child.begin();
+	for (auto parent_it = parent.begin(); parent_it != parent.end(); ++parent_it, ++child_it) {
+		if (child_it == child.end() || *child_it != *parent_it) return false;
+	}
+	return true;
+}
+
+template<typename Callback>
+void each_measurement(json_object *round, Callback callback) {
+	json_object *sides = field(round, "sides");
+	if (!sides || !json_object_is_type(sides, json_type_array)) return;
+	for (size_t side_index = 0; side_index < json_object_array_length(sides); ++side_index) {
+		json_object *side = json_object_array_get_idx(sides, side_index);
+		json_object *sections = field(side, "sections");
+		if (!sections || !json_object_is_type(sections, json_type_array)) continue;
+		for (size_t section_index = 0; section_index < json_object_array_length(sections); ++section_index) {
+			json_object *section = json_object_array_get_idx(sections, section_index);
+			json_object *measurements = field(section, "measurements");
+			if (!measurements || !json_object_is_type(measurements, json_type_array)) continue;
+			for (size_t measurement_index = 0; measurement_index < json_object_array_length(measurements); ++measurement_index) {
+				callback(json_object_array_get_idx(measurements, measurement_index));
+			}
+		}
+	}
+}
+
+struct Progress {
+	int total = 0;
+	int measured = 0;
+	int failed = 0;
+	int not_measurable = 0;
+	int skipped = 0;
+};
+
+Progress progress_for(json_object *round) {
+	Progress progress;
+	each_measurement(round, [&](json_object *measurement) {
+		++progress.total;
+		const std::string status = text_field(measurement, "status");
+		if (status != "untested" && !status.empty()) ++progress.measured;
+		if (status == "fail") ++progress.failed;
+		if (status == "not_measurable") ++progress.not_measurable;
+		if (status == "skipped") ++progress.skipped;
+	});
+	return progress;
+}
+
+void disabled_wrapped(const std::string &text) {
+	ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+	ImGui::TextWrapped("%s", text.c_str());
+	ImGui::PopStyleColor();
+}
+
+} // namespace
+
+DiagnosticsPanel::DiagnosticsPanel() : next_poll_(std::chrono::steady_clock::now()) {}
+
+DiagnosticsPanel::~DiagnosticsPanel() {
+	ClearCase();
+}
+
+filesystem::path DiagnosticsPanel::DataRoot() const {
+	if (const char *override_path = std::getenv("BOARD_DIAGNOSTICS_DATA_DIR")) {
+		if (*override_path) return normalized_path(filesystem::u8path(override_path));
+	}
+	filesystem::path base;
+	if (const char *xdg_data = std::getenv("XDG_DATA_HOME")) {
+		if (*xdg_data) base = filesystem::u8path(xdg_data);
+	}
+	if (base.empty()) {
+		const char *home = std::getenv("HOME");
+#ifdef _WIN32
+		if (!home || !*home) home = std::getenv("USERPROFILE");
+#endif
+		if (!home || !*home) return {};
+		base = filesystem::u8path(home) / ".local" / "share";
+	}
+	return base / "board-diagnostics" / "tickets";
+}
+
+filesystem::path DiagnosticsPanel::RequestPath() const {
+	const auto root = DataRoot();
+	return root.empty() ? filesystem::path{} : root.parent_path() / "open-request.json";
+}
+
+filesystem::path DiagnosticsPanel::AcknowledgementPath() const {
+	const auto root = DataRoot();
+	return root.empty() ? filesystem::path{} : root.parent_path() / "open-request-ack.json";
+}
+
+void DiagnosticsPanel::AcknowledgeRequest(const std::string &request_id) const {
+	const auto path = AcknowledgementPath();
+	if (path.empty() || request_id.empty()) return;
+	json_object *acknowledgement = json_object_new_object();
+	set_text(acknowledgement, "request_id", request_id);
+	set_text(acknowledgement, "ticket", ticket_);
+	set_text(acknowledgement, "acknowledged_at", timestamp_utc());
+	json_object_to_file_ext(path.string().c_str(), acknowledgement, JSON_C_TO_STRING_PRETTY);
+	json_object_put(acknowledgement);
+}
+
+void DiagnosticsPanel::ClearCase() {
+	if (root_) json_object_put(root_);
+	root_ = nullptr;
+	selected_case_path_.clear();
+	ticket_.clear();
+	last_located_target_.clear();
+	contextual_view_ = false;
+	edit_buffers_.clear();
+	have_case_write_time_ = false;
+}
+
+void DiagnosticsPanel::SetPreferredTicket(const std::string &ticket) {
+	preferred_ticket_ = ticket;
+	if (!candidates_.empty()) LoadPreferredOrFirstCase();
+}
+
+void DiagnosticsPanel::SetPendingTarget(const std::string &target) {
+	pending_target_ = target;
+}
+
+void DiagnosticsPanel::SetBoardFile(const filesystem::path &board_file) {
+	board_file_ = normalized_path(board_file);
+	RefreshCandidates();
+	LoadPreferredOrFirstCase();
+}
+
+bool DiagnosticsPanel::RefreshCandidates() {
+	std::vector<CaseCandidate> discovered;
+	const auto root = DataRoot();
+	std::error_code error;
+	if (!root.empty() && filesystem::is_directory(root, error)) {
+		for (const auto &entry : filesystem::directory_iterator(root, error)) {
+			if (error || !entry.is_directory()) continue;
+			const auto case_path = entry.path() / "case.json";
+			json_object *case_object = json_object_from_file(case_path.string().c_str());
+			if (!case_object) continue;
+
+			const auto workspace = text_field(case_object, "source_workspace");
+			const bool matches_board = board_file_.empty() ||
+			                           (!workspace.empty() && path_is_within(board_file_, filesystem::u8path(workspace)));
+			if (matches_board) {
+				CaseCandidate candidate;
+				candidate.path = normalized_path(case_path);
+				candidate.ticket = text_field(case_object, "ticket");
+				candidate.board = text_field(case_object, "board");
+				candidate.status = text_field(case_object, "status");
+				candidate.updated_at = text_field(case_object, "updated_at");
+				if (!candidate.ticket.empty()) discovered.push_back(std::move(candidate));
+			}
+			json_object_put(case_object);
+		}
+	}
+	std::sort(discovered.begin(), discovered.end(), [](const CaseCandidate &left, const CaseCandidate &right) {
+		if (left.updated_at != right.updated_at) return left.updated_at > right.updated_at;
+		return left.ticket < right.ticket;
+	});
+
+	const bool changed = discovered.size() != candidates_.size() ||
+	                     !std::equal(discovered.begin(), discovered.end(), candidates_.begin(), [](const auto &left, const auto &right) {
+		                     return left.path == right.path && left.updated_at == right.updated_at && left.status == right.status;
+	                     });
+	candidates_ = std::move(discovered);
+	return changed;
+}
+
+bool DiagnosticsPanel::LoadPreferredOrFirstCase() {
+	if (candidates_.empty()) {
+		ClearCase();
+		return false;
+	}
+	auto selected = candidates_.begin();
+	if (!preferred_ticket_.empty()) {
+		auto preferred = std::find_if(candidates_.begin(), candidates_.end(), [&](const CaseCandidate &candidate) {
+			return lowercase(candidate.ticket) == lowercase(preferred_ticket_);
+		});
+		if (preferred != candidates_.end()) selected = preferred;
+	} else {
+		auto active = std::find_if(candidates_.begin(), candidates_.end(), [](const CaseCandidate &candidate) {
+			return candidate.status == "in_progress" || candidate.status == "waiting_for_ai";
+		});
+		if (active != candidates_.end()) selected = active;
+	}
+	if (root_ && normalized_path(selected_case_path_) == normalized_path(selected->path)) return true;
+	return LoadCase(selected->path);
+}
+
+bool DiagnosticsPanel::LoadCase(const filesystem::path &path) {
+	json_object *loaded = json_object_from_file(path.string().c_str());
+	if (!loaded || !json_object_is_type(loaded, json_type_object)) {
+		if (loaded) json_object_put(loaded);
+		notice_ = std::string("Could not load diagnostic ticket: ") + json_util_get_last_err();
+		notice_is_error_ = true;
+		return false;
+	}
+	const std::string loaded_ticket = text_field(loaded, "ticket");
+	if (loaded_ticket.empty() || !field(loaded, "rounds")) {
+		json_object_put(loaded);
+		notice_ = "Diagnostic case is missing its ticket or rounds.";
+		notice_is_error_ = true;
+		return false;
+	}
+
+	if (root_) json_object_put(root_);
+	root_ = loaded;
+	selected_case_path_ = normalized_path(path);
+	ticket_ = loaded_ticket;
+	preferred_ticket_ = loaded_ticket;
+	edit_buffers_.clear();
+	notice_.clear();
+	notice_is_error_ = false;
+	std::error_code error;
+	case_write_time_ = filesystem::last_write_time(selected_case_path_, error);
+	have_case_write_time_ = !error;
+	return true;
+}
+
+bool DiagnosticsPanel::RequestMatchesBoard(json_object *request) const {
+	const std::string requested_board = text_field(request, "board_file");
+	if (requested_board.empty() || board_file_.empty()) return false;
+	return normalized_path(filesystem::u8path(requested_board)) == board_file_;
+}
+
+bool DiagnosticsPanel::PollOpenRequest() {
+	if (board_file_.empty()) return false;
+	const auto request_path = RequestPath();
+	if (request_path.empty()) return false;
+	std::error_code error;
+	const auto write_time = filesystem::last_write_time(request_path, error);
+	if (error || (have_request_write_time_ && write_time == request_write_time_)) return false;
+	request_write_time_ = write_time;
+	have_request_write_time_ = true;
+
+	json_object *request = json_object_from_file(request_path.string().c_str());
+	if (!request) return false;
+	const bool matches = RequestMatchesBoard(request);
+	bool handled = false;
+	if (matches) {
+		preferred_ticket_ = text_field(request, "ticket");
+		pending_target_ = text_field(request, "target");
+		RefreshCandidates();
+		handled = LoadPreferredOrFirstCase();
+		if (handled) AcknowledgeRequest(text_field(request, "request_id"));
+	}
+	json_object_put(request);
+	return handled;
+}
+
+bool DiagnosticsPanel::PollForChanges() {
+	const auto now = std::chrono::steady_clock::now();
+	if (now < next_poll_) return false;
+	next_poll_ = now + std::chrono::milliseconds(250);
+
+	bool attention = PollOpenRequest();
+	const bool candidates_changed = RefreshCandidates();
+	if (!root_ && !candidates_.empty()) attention |= LoadPreferredOrFirstCase();
+	if (root_ && candidates_changed) {
+		auto selected = std::find_if(candidates_.begin(), candidates_.end(), [&](const CaseCandidate &candidate) {
+			return candidate.path == selected_case_path_;
+		});
+		if (selected == candidates_.end()) {
+			attention |= LoadPreferredOrFirstCase();
+		}
+	}
+
+	if (root_ && !selected_case_path_.empty()) {
+		std::error_code error;
+		const auto write_time = filesystem::last_write_time(selected_case_path_, error);
+		if (!error && (!have_case_write_time_ || write_time != case_write_time_)) {
+			attention |= LoadCase(selected_case_path_);
+		}
+	}
+	return attention;
+}
+
+bool DiagnosticsPanel::HasCase() const {
+	return root_ != nullptr;
+}
+
+const std::string &DiagnosticsPanel::Ticket() const {
+	return ticket_;
+}
+
+std::string DiagnosticsPanel::TakePendingTarget() {
+	std::string target = pending_target_;
+	pending_target_.clear();
+	return target;
+}
+
+json_object *DiagnosticsPanel::ActiveRound() const {
+	if (!root_) return nullptr;
+	json_object *rounds = field(root_, "rounds");
+	if (!rounds || !json_object_is_type(rounds, json_type_array)) return nullptr;
+	const std::string active_id = text_field(root_, "active_round_id");
+	json_object *fallback = nullptr;
+	for (size_t index = 0; index < json_object_array_length(rounds); ++index) {
+		json_object *round = json_object_array_get_idx(rounds, index);
+		fallback = round;
+		if (!active_id.empty() && text_field(round, "id") == active_id) return round;
+	}
+	return fallback;
+}
+
+std::string &DiagnosticsPanel::EditableBuffer(const std::string &key, const std::string &initial) {
+	auto [entry, inserted] = edit_buffers_.try_emplace(key, initial);
+	return entry->second;
+}
+
+bool DiagnosticsPanel::SaveCase() {
+	if (!root_ || selected_case_path_.empty()) return false;
+	set_text(root_, "updated_at", timestamp_utc());
+	const char *serialized = json_object_to_json_string_ext(root_, JSON_C_TO_STRING_PRETTY);
+	if (!serialized) {
+		notice_ = "Could not serialize the diagnostic ticket.";
+		notice_is_error_ = true;
+		return false;
+	}
+
+	auto temporary = selected_case_path_;
+#ifdef _WIN32
+	temporary += ".tmp";
+#else
+	temporary += ".tmp." + std::to_string(getpid());
+#endif
+	{
+		std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+		if (!output) {
+			notice_ = "Could not create the temporary diagnostic file.";
+			notice_is_error_ = true;
+			return false;
+		}
+		output << serialized << '\n';
+		output.flush();
+		if (!output) {
+			notice_ = "Could not write the diagnostic ticket.";
+			notice_is_error_ = true;
+			return false;
+		}
+	}
+#ifndef _WIN32
+	chmod(temporary.string().c_str(), S_IRUSR | S_IWUSR);
+#endif
+	std::error_code error;
+	filesystem::rename(temporary, selected_case_path_, error);
+	if (error) {
+		filesystem::remove(temporary, error);
+		notice_ = "Could not replace the diagnostic ticket file.";
+		notice_is_error_ = true;
+		return false;
+	}
+	case_write_time_ = filesystem::last_write_time(selected_case_path_, error);
+	have_case_write_time_ = !error;
+	notice_is_error_ = false;
+	return true;
+}
+
+void DiagnosticsPanel::MarkEdited(json_object *round) {
+	const std::string now = timestamp_utc();
+	set_text(round, "updated_at", now);
+	if (text_field(round, "status") == "complete") {
+		set_text(round, "status", "in_progress");
+		json_object_object_add(round, "completed_at", json_object_new_null());
+		set_text(root_, "status", "in_progress");
+	}
+}
+
+std::string DiagnosticsPanel::DependencyState(json_object *round, json_object *measurement) const {
+	json_object *requirements = field(measurement, "requires_pass");
+	if (!requirements || !json_object_is_type(requirements, json_type_array) || json_object_array_length(requirements) == 0) {
+		return "ready";
+	}
+
+	std::unordered_map<std::string, json_object *> by_key;
+	each_measurement(round, [&](json_object *candidate) {
+		std::string key = text_field(candidate, "key");
+		if (key.empty()) key = text_field(candidate, "id");
+		if (!key.empty()) by_key[key] = candidate;
+	});
+
+	bool all_passed = true;
+	for (size_t index = 0; index < json_object_array_length(requirements); ++index) {
+		json_object *required = json_object_array_get_idx(requirements, index);
+		const char *key_text = required ? json_object_get_string(required) : nullptr;
+		if (!key_text || !by_key.count(key_text)) return "pending";
+		const std::string status = text_field(by_key[key_text], "status");
+		if (status == "fail" || status == "not_measurable" || status == "skipped") return "skipped";
+		if (status != "pass") all_passed = false;
+	}
+	return all_passed ? "ready" : "pending";
+}
+
+void DiagnosticsPanel::ApplyDependencies(json_object *round) {
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		each_measurement(round, [&](json_object *measurement) {
+			const std::string state = DependencyState(round, measurement);
+			const std::string status = text_field(measurement, "status");
+			const bool auto_skipped = bool_field(measurement, "auto_skipped");
+			if (state == "skipped" && (status == "untested" || status == "skipped" || status.empty())) {
+				if (status != "skipped" || !auto_skipped) {
+					set_text(measurement, "status", "skipped");
+					set_bool(measurement, "auto_skipped", true);
+					changed = true;
+				}
+			} else if (state != "skipped" && auto_skipped) {
+				set_text(measurement, "status", "untested");
+				set_bool(measurement, "auto_skipped", false);
+				changed = true;
+			}
+		});
+	}
+}
+
+void DiagnosticsPanel::SetMeasurementStatus(json_object *round, json_object *measurement, const std::string &status) {
+	set_text(measurement, "status", status);
+	set_bool(measurement, "auto_skipped", false);
+	ApplyDependencies(round);
+	MarkEdited(round);
+	SaveCase();
+}
+
+void DiagnosticsPanel::SetMeasurementActual(json_object *round, json_object *measurement, const std::string &actual) {
+	set_text(measurement, "actual", actual);
+	MarkEdited(round);
+	SaveCase();
+}
+
+void DiagnosticsPanel::SetSideComments(json_object *round, json_object *side, const std::string &comments) {
+	set_text(side, "comments", comments);
+	MarkEdited(round);
+	SaveCase();
+}
+
+void DiagnosticsPanel::FinishRound(json_object *round) {
+	const Progress progress = progress_for(round);
+	if (progress.total == 0 || progress.measured != progress.total) {
+		notice_ = "Resolve every required measurement before finishing the round.";
+		notice_is_error_ = true;
+		return;
+	}
+	const std::string now = timestamp_utc();
+	set_text(round, "status", "complete");
+	set_text(round, "updated_at", now);
+	set_text(round, "completed_at", now);
+	set_text(root_, "status", "waiting_for_ai");
+	if (SaveCase()) {
+		notice_ = "Round finished. Return to your AI assistant for the next round.";
+		notice_is_error_ = false;
+	}
+}
+
+void DiagnosticsPanel::DrawTicketPicker() {
+	if (candidates_.size() <= 1) {
+		ImGui::Text("Ticket %s", ticket_.c_str());
+		return;
+	}
+	const std::string label = "Ticket " + ticket_;
+	if (ImGui::BeginCombo("##diagnostic-ticket", label.c_str())) {
+		for (const auto &candidate : candidates_) {
+			const bool selected = candidate.path == selected_case_path_;
+			const std::string item = candidate.ticket + " - " + candidate.board;
+			if (ImGui::Selectable(item.c_str(), selected)) LoadCase(candidate.path);
+			if (selected) ImGui::SetItemDefaultFocus();
+		}
+		ImGui::EndCombo();
+	}
+}
+
+void DiagnosticsPanel::DrawMeasurement(json_object *round, json_object *measurement, const LocateCallback &locate) {
+	ImGui::PushID(measurement);
+	const bool visible = ImGui::BeginChild("##measurement",
+	                                       ImVec2(-1.0f, 0.0f),
+	                                       ImGuiChildFlags_FrameStyle | ImGuiChildFlags_AutoResizeY);
+	if (!visible) {
+		ImGui::EndChild();
+		ImGui::PopID();
+		return;
+	}
+
+	const std::string point = text_field(measurement, "point");
+	const std::string reference = text_field(measurement, "reference");
+	const std::string target = text_field(measurement, "boardview");
+	ImGui::TextWrapped("%s -> %s", point.c_str(), reference.c_str());
+	if (!target.empty()) {
+		if (ImGui::Button("Boardview", ImVec2(-1.0f, 0.0f))) {
+			const bool same_target = lowercase(last_located_target_) == lowercase(target);
+			const bool show_context = same_target ? !contextual_view_ : false;
+			std::string error;
+			if (locate(target, show_context, error)) {
+				last_located_target_ = target;
+				contextual_view_ = show_context;
+				notice_ = show_context ? "Showing " + target + " in board context."
+				                           : "Located " + target + ".";
+				notice_is_error_ = false;
+			} else {
+				notice_ = error.empty() ? "The board target could not be located." : error;
+				notice_is_error_ = true;
+			}
+		}
+		if (ImGui::IsItemHovered()) {
+			const bool same_target = lowercase(last_located_target_) == lowercase(target);
+			ImGui::SetTooltip("%s", same_target && !contextual_view_ ? "Click again to zoom out" : "Show on the board");
+		}
+	}
+
+	const std::string expected = text_field(measurement, "expected");
+	ImGui::TextDisabled("Expected");
+	ImGui::TextWrapped("%s", expected.c_str());
+	const std::string probe = text_field(measurement, "probe");
+	if (!probe.empty()) {
+		ImGui::TextDisabled("Probe placement");
+		ImGui::TextWrapped("%s", probe.c_str());
+	}
+	const std::string location = text_field(measurement, "location");
+	if (!location.empty()) ImGui::TextDisabled("%s", location.c_str());
+	const std::string why = text_field(measurement, "why");
+	if (!why.empty() && ImGui::IsItemHovered()) ImGui::SetTooltip("%s", why.c_str());
+
+	const std::string dependency = DependencyState(round, measurement);
+	const std::string status = text_field(measurement, "status").empty() ? "untested" : text_field(measurement, "status");
+	const bool locked = dependency != "ready" && (status == "untested" || status == "skipped");
+	if (dependency == "pending") ImGui::TextDisabled("Waiting for prerequisite measurements");
+	if (dependency == "skipped") ImGui::TextDisabled("Skipped because a prerequisite did not pass");
+
+	ImGui::BeginDisabled(locked);
+	const std::string buffer_key = text_field(round, "id") + "/" + text_field(measurement, "id") + "/actual";
+	std::string &actual = EditableBuffer(buffer_key, text_field(measurement, "actual"));
+	ImGui::TextDisabled("Actual");
+	ImGui::SetNextItemWidth(-1.0f);
+	if (ImGui::InputText("##actual", &actual)) SetMeasurementActual(round, measurement, actual);
+
+	const float status_spacing = ImGui::GetStyle().ItemSpacing.x;
+	const float status_width = (ImGui::GetContentRegionAvail().x - status_spacing * 2.0f) / 3.0f;
+	auto status_button = [&](const char *label, const char *value, const ImVec4 &color) {
+		const bool active = status == value;
+		if (active) {
+			ImVec4 active_color = color;
+			active_color.w = 0.55f;
+			ImGui::PushStyleColor(ImGuiCol_Button, active_color);
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, active_color);
+		}
+		if (ImGui::Button(label, ImVec2(status_width, 0.0f))) SetMeasurementStatus(round, measurement, active ? "untested" : value);
+		if (active) ImGui::PopStyleColor(2);
+	};
+	const ImGuiStyle &style = ImGui::GetStyle();
+	status_button("Pass##status", "pass", style.Colors[ImGuiCol_CheckMark]);
+	ImGui::SameLine();
+	status_button("Wrong##status", "fail", style.Colors[ImGuiCol_PlotLinesHovered]);
+	ImGui::SameLine();
+	status_button("N/A##status", "not_measurable", style.Colors[ImGuiCol_TextDisabled]);
+	if (ImGui::IsItemHovered()) ImGui::SetTooltip("Can't measure");
+	ImGui::EndDisabled();
+	ImGui::EndChild();
+	ImGui::Dummy(ImVec2(0.0f, ImGui::GetStyle().ItemSpacing.y * 0.35f));
+	ImGui::PopID();
+}
+
+void DiagnosticsPanel::DrawSection(json_object *round, json_object *section, const LocateCallback &locate) {
+	std::string heading = text_field(section, "title");
+	const std::string mode = text_field(section, "mode");
+	const std::string power_state = text_field(section, "power_state");
+	if (!mode.empty() || !power_state.empty()) heading += " [" + mode + ", power " + power_state + "]";
+	ImGui::Separator();
+	ImGui::TextWrapped("%s", heading.c_str());
+	const std::string safety = text_field(section, "safety");
+	if (!safety.empty()) {
+		ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_PlotHistogramHovered));
+		ImGui::TextWrapped("%s", safety.c_str());
+		ImGui::PopStyleColor();
+	}
+
+	json_object *measurements = field(section, "measurements");
+	if (!measurements || !json_object_is_type(measurements, json_type_array)) return;
+	for (size_t index = 0; index < json_object_array_length(measurements); ++index) {
+		DrawMeasurement(round, json_object_array_get_idx(measurements, index), locate);
+	}
+}
+
+void DiagnosticsPanel::DrawSide(json_object *round, json_object *side, const LocateCallback &locate) {
+	json_object *sections = field(side, "sections");
+	if (sections && json_object_is_type(sections, json_type_array)) {
+		for (size_t index = 0; index < json_object_array_length(sections); ++index) {
+			DrawSection(round, json_object_array_get_idx(sections, index), locate);
+		}
+	}
+
+	ImGui::SeparatorText("Comments");
+	const std::string key = text_field(round, "id") + "/" + text_field(side, "id") + "/comments";
+	std::string &comments = EditableBuffer(key, text_field(side, "comments"));
+	const float comments_height = ImGui::GetTextLineHeightWithSpacing() * 4.5f;
+	if (ImGui::InputTextMultiline("##side-comments", &comments, ImVec2(-1.0f, comments_height))) SetSideComments(round, side, comments);
+}
+
+void DiagnosticsPanel::DrawRound(json_object *round, const LocateCallback &locate) {
+	const std::string heading = "Round " + std::to_string(json_object_get_int(field(round, "number"))) + ": " +
+	                            text_field(round, "title");
+	ImGui::Separator();
+	ImGui::TextWrapped("%s", heading.c_str());
+	const std::string summary = text_field(round, "summary");
+	if (!summary.empty()) ImGui::TextWrapped("%s", summary.c_str());
+
+	json_object *instructions = field(round, "instructions");
+	if (instructions && json_object_is_type(instructions, json_type_array)) {
+		for (size_t index = 0; index < json_object_array_length(instructions); ++index) {
+			json_object *instruction = json_object_array_get_idx(instructions, index);
+			ImGui::Bullet();
+			ImGui::SameLine();
+			ImGui::TextWrapped("%s", instruction ? json_object_get_string(instruction) : "");
+		}
+	}
+
+	json_object *sides = field(round, "sides");
+	if (sides && json_object_is_type(sides, json_type_array) && ImGui::BeginTabBar("##diagnostic-sides")) {
+		for (size_t index = 0; index < json_object_array_length(sides); ++index) {
+			json_object *side = json_object_array_get_idx(sides, index);
+			const std::string name = text_field(side, "name");
+			if (ImGui::BeginTabItem(name.c_str())) {
+				DrawSide(round, side, locate);
+				ImGui::EndTabItem();
+			}
+		}
+		ImGui::EndTabBar();
+	}
+
+	const Progress progress = progress_for(round);
+	ImGui::SeparatorText("Progress");
+	const std::string progress_text = std::to_string(progress.measured) + " of " + std::to_string(progress.total) + " checked";
+	const float progress_fraction = progress.total > 0 ? static_cast<float>(progress.measured) / progress.total : 0.0f;
+	ImGui::ProgressBar(progress_fraction, ImVec2(-1.0f, 0.0f), progress_text.c_str());
+	if (progress.failed || progress.not_measurable || progress.skipped) {
+		ImGui::TextDisabled("%d wrong  |  %d not measurable  |  %d skipped",
+		                    progress.failed,
+		                    progress.not_measurable,
+		                    progress.skipped);
+	}
+	const bool complete = text_field(round, "status") == "complete";
+	ImGui::BeginDisabled(complete || progress.total == 0 || progress.measured != progress.total);
+	if (ImGui::Button(complete ? "Finished" : "Finish round", ImVec2(-1.0f, 0.0f))) FinishRound(round);
+	ImGui::EndDisabled();
+}
+
+void DiagnosticsPanel::Draw(const LocateCallback &locate) {
+	PollForChanges();
+	if (!root_) {
+		ImGui::TextWrapped("No diagnostic ticket matches this board file.");
+		if (ImGui::Button("Refresh tickets")) {
+			RefreshCandidates();
+			LoadPreferredOrFirstCase();
+		}
+		return;
+	}
+
+	DrawTicketPicker();
+	const std::string board = text_field(root_, "board");
+	if (!board.empty()) disabled_wrapped(board);
+	if (json_object *round = ActiveRound()) DrawRound(round, locate);
+	else ImGui::TextWrapped("This ticket has no active round.");
+
+	if (!notice_.empty()) {
+		const ImVec4 color = ImGui::GetStyleColorVec4(notice_is_error_ ? ImGuiCol_PlotLinesHovered : ImGuiCol_CheckMark);
+		ImGui::TextColored(color, "%s", notice_.c_str());
+	}
+}

--- a/src/openboardview/DiagnosticsPanel.h
+++ b/src/openboardview/DiagnosticsPanel.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "filesystem_impl.h"
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct json_object;
+
+class DiagnosticsPanel {
+public:
+	using LocateCallback = std::function<bool(const std::string &, bool, std::string &)>;
+
+	DiagnosticsPanel();
+	~DiagnosticsPanel();
+
+	DiagnosticsPanel(const DiagnosticsPanel &) = delete;
+	DiagnosticsPanel &operator=(const DiagnosticsPanel &) = delete;
+
+	void SetBoardFile(const filesystem::path &board_file);
+	void SetPreferredTicket(const std::string &ticket);
+	void SetPendingTarget(const std::string &target);
+
+	// Polls ticket/request files. Returns true when external state requests attention.
+	bool PollForChanges();
+	bool HasCase() const;
+	const std::string &Ticket() const;
+	std::string TakePendingTarget();
+
+	void Draw(const LocateCallback &locate);
+
+private:
+	struct CaseCandidate {
+		filesystem::path path;
+		std::string ticket;
+		std::string board;
+		std::string status;
+		std::string updated_at;
+	};
+
+	filesystem::path board_file_;
+	filesystem::path selected_case_path_;
+	std::vector<CaseCandidate> candidates_;
+	json_object *root_ = nullptr;
+	std::unordered_map<std::string, std::string> edit_buffers_;
+	std::string preferred_ticket_;
+	std::string pending_target_;
+	std::string ticket_;
+	std::string notice_;
+	std::string last_located_target_;
+	bool notice_is_error_ = false;
+	bool contextual_view_ = false;
+	bool have_case_write_time_ = false;
+	bool have_request_write_time_ = false;
+	filesystem::file_time_type case_write_time_{};
+	filesystem::file_time_type request_write_time_{};
+	std::chrono::steady_clock::time_point next_poll_{};
+
+	filesystem::path DataRoot() const;
+	filesystem::path RequestPath() const;
+	filesystem::path AcknowledgementPath() const;
+	void AcknowledgeRequest(const std::string &request_id) const;
+	void ClearCase();
+	bool RefreshCandidates();
+	bool LoadCase(const filesystem::path &path);
+	bool LoadPreferredOrFirstCase();
+	bool PollOpenRequest();
+	bool RequestMatchesBoard(json_object *request) const;
+	bool SaveCase();
+
+	json_object *ActiveRound() const;
+	std::string &EditableBuffer(const std::string &key, const std::string &initial);
+	void MarkEdited(json_object *round);
+	void ApplyDependencies(json_object *round);
+	std::string DependencyState(json_object *round, json_object *measurement) const;
+	void SetMeasurementStatus(json_object *round, json_object *measurement, const std::string &status);
+	void SetMeasurementActual(json_object *round, json_object *measurement, const std::string &actual);
+	void SetSideComments(json_object *round, json_object *side, const std::string &comments);
+	void FinishRound(json_object *round);
+
+	void DrawTicketPicker();
+	void DrawRound(json_object *round, const LocateCallback &locate);
+	void DrawSide(json_object *round, json_object *side, const LocateCallback &locate);
+	void DrawSection(json_object *round, json_object *section, const LocateCallback &locate);
+	void DrawMeasurement(json_object *round, json_object *measurement, const LocateCallback &locate);
+};

--- a/src/openboardview/main_opengl.cpp
+++ b/src/openboardview/main_opengl.cpp
@@ -14,6 +14,9 @@
 
 #include "BoardView.h"
 #include "history.h"
+#ifdef ENABLE_DIAGNOSTICS
+#include "AgentSkillInstaller.h"
+#endif
 
 #include "confparse.h"
 #include "resource.h"
@@ -55,6 +58,10 @@ struct globals {
 	int dpi = 0;
 	float font_size = 0.0f;
 	bool debug = false;
+#ifdef ENABLE_DIAGNOSTICS
+	char *diagnostics_ticket = nullptr;
+	char *diagnostics_target = nullptr;
+#endif
 	Renderers::Renderer renderer = Renderers::Renderer::DEFAULT;
 #ifdef _WIN32
 	char *pdfBridgePdfPath = nullptr;
@@ -64,21 +71,28 @@ struct globals {
 
 static SDL_Window *window      = nullptr;
 
+#ifdef ENABLE_DIAGNOSTICS
+#define DIAGNOSTICS_HELP                                                                                              \
+	"\t--ticket <ticket> : open the matching Board Diagnostics ticket\n"                                             \
+	"\t--locate <component-or-net> : locate a diagnostic target after loading the board\n"
+#else
+#define DIAGNOSTICS_HELP ""
+#endif
+
 char help[] =
-    " [-h] [-V] [-l] [-c <config file>] [-i <intput file>] [-x <width>] [-y <height>] [-z <fontsize>] [-p <dpi>] [-r <renderer>] [-d]\n\
-	-h : This help\n\
-	-V : Version information\n\
-	-l : slow CPU mode, disables AA and other items to try provide more FPS\n\
-	-c <config file> : alternative configuration file (default is ~/.config/" OBV_NAME
-    "/obv.conf)\n\
-	-i <input file> : board file to load\n\
-	-x <width> : Set window width\n\
-	-y <height> : Set window height\n\
-	-z <pixels> : Set font size\n\
-	-p <dpi> : Set the dpi\n\
-	-r <renderer> : Set the renderer [ OPENGL1 = 1; OPENGL3 = 2; OPENGLES2 = 3 ]\n\
-	-d : Debug mode\n\
-";
+    " [-h] [-V] [-l] [-c <config file>] [-i <intput file>] [-x <width>] [-y <height>] [-z <fontsize>] [-p <dpi>] [-r <renderer>] [-d]\n"
+	"\t-h : This help\n"
+	"\t-V : Version information\n"
+	"\t-l : slow CPU mode, disables AA and other items to try provide more FPS\n"
+	"\t-c <config file> : alternative configuration file (default is ~/.config/" OBV_NAME "/obv.conf)\n"
+	"\t-i <input file> : board file to load\n"
+	"\t-x <width> : Set window width\n"
+	"\t-y <height> : Set window height\n"
+	"\t-z <pixels> : Set font size\n"
+	"\t-p <dpi> : Set the dpi\n"
+	"\t-r <renderer> : Set the renderer [ OPENGL1 = 1; OPENGL3 = 2; OPENGLES2 = 3 ]\n"
+	"\t-d : Debug mode\n"
+	DIAGNOSTICS_HELP;
 
 int parse_parameters(int argc, char **argv, struct globals *g) {
 	int param;
@@ -173,6 +187,24 @@ int parse_parameters(int argc, char **argv, struct globals *g) {
 
 		} else if (strcmp(p, "-d") == 0) {
 			g->debug = true;
+#ifdef ENABLE_DIAGNOSTICS
+		} else if (strcmp(p, "--ticket") == 0) {
+			param++;
+			if (param < argc && argv[param][0] != '-') {
+				g->diagnostics_ticket = argv[param];
+			} else {
+				SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Not enough parameters for --ticket <ticket>\n");
+				exit(1);
+			}
+		} else if (strcmp(p, "--locate") == 0) {
+			param++;
+			if (param < argc && argv[param][0] != '-') {
+				g->diagnostics_target = argv[param];
+			} else {
+				SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Not enough parameters for --locate <component-or-net>\n");
+				exit(1);
+			}
+#endif
 #ifdef _WIN32
 		} else if (!strncmp(p, "--reversesearch", 15)) {
 			// Handling of DDE command for PDFBridge
@@ -237,6 +269,10 @@ int main(int argc, char **argv) {
 	parse_parameters(argc, argv, &g);
 
 	app.debug = g.debug;
+#ifdef ENABLE_DIAGNOSTICS
+	if (g.diagnostics_ticket) app.SetDiagnosticTicket(g.diagnostics_ticket);
+	if (g.diagnostics_target) app.SetDiagnosticTarget(g.diagnostics_target);
+#endif
 
 	// Log all messages
 	if (app.debug) {
@@ -248,6 +284,10 @@ int main(int argc, char **argv) {
 		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Error: %s\n", SDL_GetError());
 		return -1;
 	}
+
+#ifdef ENABLE_DIAGNOSTICS
+	InstallBundledBoardDiagnosticsSkill();
+#endif
 
 #ifdef __APPLE__
 	// Add some menu items to system and dock menu bar on macOS
@@ -433,6 +473,14 @@ int main(int argc, char **argv) {
 
 			if (event.type == SDL_QUIT) done = true;
 		}
+
+#ifdef ENABLE_DIAGNOSTICS
+		if (app.PollDiagnostics()) {
+			if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED) SDL_RestoreWindow(window);
+			SDL_RaiseWindow(window);
+			sleepout = 30;
+		}
+#endif
 
 		// reset rotation angle accumulator
 		if (ImGui::IsMouseDown(ImGuiMouseButton_Left)) {

--- a/tests/test_board_diagnostics.py
+++ b/tests/test_board_diagnostics.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "board-diagnostics"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS))
+
+import board_diagnostics_core as core  # noqa: E402
+import board_diagnostics as cli  # noqa: E402
+
+
+def sample_plan(title: str = "Initial checks") -> dict:
+    return {
+        "title": title,
+        "summary": "Verify the first diagnostic split.",
+        "instructions": ["Follow each section's power state."],
+        "sides": [
+            {
+                "name": "Side A",
+                "sections": [
+                    {
+                        "title": "Powered voltage",
+                        "mode": "voltage",
+                        "power_state": "connected",
+                        "safety": "Use a current-limited supply.",
+                        "measurements": [
+                            {
+                                "point": "TP_A",
+                                "reference": "GND",
+                                "expected": "5 V",
+                                "location": "Upper left",
+                                "why": "Separates input from downstream fault.",
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "Side B",
+                "sections": [
+                    {
+                        "title": "Unpowered resistance",
+                        "mode": "resistance",
+                        "power_state": "disconnected",
+                        "safety": "Disconnect every power source.",
+                        "measurements": [
+                            {
+                                "point": "TP_B",
+                                "reference": "GND",
+                                "expected": "0-1 ohm",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+
+
+class BoardDiagnosticsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.previous_data_dir = os.environ.get("BOARD_DIAGNOSTICS_DATA_DIR")
+        os.environ["BOARD_DIAGNOSTICS_DATA_DIR"] = str(Path(self.temporary.name) / "data")
+        self.workspace = Path(self.temporary.name) / "workspace"
+        self.workspace.mkdir()
+
+    def tearDown(self) -> None:
+        if self.previous_data_dir is None:
+            os.environ.pop("BOARD_DIAGNOSTICS_DATA_DIR", None)
+        else:
+            os.environ["BOARD_DIAGNOSTICS_DATA_DIR"] = self.previous_data_dir
+        self.temporary.cleanup()
+
+    def create(self, ticket: str = "1002") -> dict:
+        case, _path = core.create_case(
+            ticket,
+            "Example board",
+            "No power",
+            sample_plan(),
+            workspace=self.workspace,
+        )
+        return case
+
+    def test_ticket_normalization_and_validation(self) -> None:
+        self.assertEqual(core.normalize_ticket(" #ABC-123 "), "ABC-123")
+        with self.assertRaises(core.DiagnosticError):
+            core.normalize_ticket("../123")
+        with self.assertRaises(core.DiagnosticError):
+            core.normalize_ticket("")
+
+    def test_rejects_powered_resistance(self) -> None:
+        plan = sample_plan()
+        section = plan["sides"][1]["sections"][0]
+        section["power_state"] = "connected"
+        with self.assertRaisesRegex(core.DiagnosticError, "resistance mode"):
+            core.normalize_plan(plan, 1)
+
+    def test_requires_both_board_sides(self) -> None:
+        plan = sample_plan()
+        plan["sides"][1]["name"] = "Rear"
+        with self.assertRaisesRegex(core.DiagnosticError, "Side A and Side B"):
+            core.normalize_plan(plan, 1)
+
+    def test_case_lifecycle_preserves_rounds(self) -> None:
+        case = self.create()
+        round_data = core.active_round(case)
+        for side in round_data["sides"]:
+            for section in side["sections"]:
+                for measurement in section["measurements"]:
+                    core.update_measurement(
+                        case,
+                        round_data["id"],
+                        side["id"],
+                        section["id"],
+                        measurement["id"],
+                        actual=measurement["expected"],
+                        status="pass",
+                    )
+        core.update_side_comments(case, round_data["id"], "side-a", "Stable reading")
+        core.finish_active_round(case)
+
+        saved = core.load_case("1002")
+        self.assertEqual(saved["status"], "waiting_for_ai")
+        self.assertEqual(core.round_progress(core.active_round(saved))["pass"], 2)
+
+        saved, _path = core.add_round("1002", sample_plan("Follow-up checks"))
+        self.assertEqual(len(saved["rounds"]), 2)
+        self.assertEqual(core.active_round(saved)["number"], 2)
+        self.assertEqual(saved["rounds"][0]["status"], "complete")
+
+    def test_actual_defaults_to_expected_without_marking_tested(self) -> None:
+        case = self.create()
+        round_data = core.active_round(case)
+        measurements = list(core.iter_measurements(round_data))
+        self.assertTrue(measurements)
+        self.assertTrue(all(item["actual"] == item["expected"] for item in measurements))
+        self.assertEqual(core.round_progress(round_data)["measured"], 0)
+
+    def test_boardview_target_is_inferred_from_component(self) -> None:
+        plan = sample_plan()
+        measurement = plan["sides"][0]["sections"][0]["measurements"][0]
+        measurement["point"] = "R7009 inner pad"
+        normalized = core.normalize_plan(plan, 1)
+        first = next(core.iter_measurements(normalized))
+        self.assertEqual(first["boardview"], "R7009")
+
+    def test_failed_prerequisite_skips_and_restores_downstream_checks(self) -> None:
+        plan = sample_plan()
+        measurements = plan["sides"][0]["sections"][0]["measurements"]
+        measurements[0]["key"] = "input_ok"
+        measurements.append(
+            {
+                "key": "downstream",
+                "point": "R7009",
+                "reference": "GND",
+                "expected": "3.3 V",
+                "requires_pass": ["input_ok"],
+            }
+        )
+        case, _path = core.create_case(
+            "branching", "Example board", "No power", plan, workspace=self.workspace
+        )
+        round_data = core.active_round(case)
+        by_key = core.measurements_by_key(round_data)
+        self.assertEqual(core.dependency_state(round_data, by_key["downstream"]), "pending")
+
+        source = by_key["input_ok"]
+        core.update_measurement(
+            case,
+            round_data["id"],
+            "side-a",
+            round_data["sides"][0]["sections"][0]["id"],
+            source["id"],
+            status="fail",
+        )
+        self.assertEqual(by_key["downstream"]["status"], "skipped")
+        self.assertTrue(by_key["downstream"]["auto_skipped"])
+        self.assertEqual(core.round_progress(round_data)["skipped"], 1)
+
+        core.update_measurement(
+            case,
+            round_data["id"],
+            "side-a",
+            round_data["sides"][0]["sections"][0]["id"],
+            source["id"],
+            status="pass",
+        )
+        self.assertEqual(by_key["downstream"]["status"], "untested")
+        self.assertFalse(by_key["downstream"]["auto_skipped"])
+        self.assertEqual(core.dependency_state(round_data, by_key["downstream"]), "ready")
+
+    def test_rejects_unknown_and_cyclic_dependencies(self) -> None:
+        plan = sample_plan()
+        first = plan["sides"][0]["sections"][0]["measurements"][0]
+        first["key"] = "first"
+        first["requires_pass"] = ["missing"]
+        with self.assertRaisesRegex(core.DiagnosticError, "unknown key"):
+            core.normalize_plan(plan, 1)
+
+        first["requires_pass"] = ["second"]
+        plan["sides"][1]["sections"][0]["measurements"][0].update(
+            {"key": "second", "requires_pass": ["first"]}
+        )
+        with self.assertRaisesRegex(core.DiagnosticError, "cycle"):
+            core.normalize_plan(plan, 1)
+
+    def test_can_replace_untouched_round_but_not_edited_round(self) -> None:
+        case = self.create()
+        replacement = sample_plan("Broader checks")
+        saved, _path = core.replace_active_round("1002", replacement)
+        self.assertEqual(core.active_round(saved)["title"], "Broader checks")
+        self.assertEqual(len(saved["rounds"]), 1)
+
+        round_data = core.active_round(saved)
+        first = next(core.iter_measurements(round_data))
+        first["actual"] = "unexpected"
+        core.save_case(saved)
+        with self.assertRaisesRegex(core.DiagnosticError, "edited readings"):
+            core.replace_active_round("1002", sample_plan("Rejected"))
+
+    def test_cannot_replace_or_append_to_unfinished_ticket(self) -> None:
+        self.create()
+        with self.assertRaisesRegex(core.DiagnosticError, "already exists"):
+            self.create()
+        with self.assertRaisesRegex(core.DiagnosticError, "unfinished active round"):
+            core.add_round("1002", sample_plan("Too soon"))
+
+    def test_results_and_natural_ticket_order(self) -> None:
+        for ticket in ("10", "2", "A3"):
+            core.create_case(
+                ticket,
+                "Example board",
+                "No power",
+                sample_plan(),
+                workspace=self.workspace,
+            )
+        tickets = [item["ticket"] for item in core.list_cases()]
+        self.assertEqual(tickets, ["2", "10", "A3"])
+        report = core.format_results_markdown(core.load_case("2"))
+        self.assertIn("# Ticket 2", report)
+        self.assertIn("Side A", report)
+        self.assertIn("○ UNTESTED", report)
+
+    def test_open_reuses_matching_boardview_window(self) -> None:
+        case = self.create()
+        board_file = self.workspace / "example.brd"
+        board_file.touch()
+
+        with (
+            mock.patch.object(cli, "wait_for_acknowledgement", return_value=True),
+            mock.patch.object(cli.subprocess, "Popen") as popen,
+        ):
+            self.assertEqual(cli.launch_app(case["ticket"], "TP_A"), 0)
+
+        popen.assert_not_called()
+        request = json.loads(
+            (core.data_root().parent / "open-request.json").read_text(encoding="utf-8")
+        )
+        self.assertRegex(request["request_id"], r"^[0-9a-f]{32}$")
+        self.assertEqual(request["ticket"], case["ticket"])
+        self.assertEqual(request["board_file"], str(board_file.resolve()))
+        self.assertEqual(request["target"], "TP_A")
+
+    def test_open_starts_boardview_when_no_window_acknowledges(self) -> None:
+        case = self.create()
+        board_file = self.workspace / "example.brd"
+        board_file.touch()
+        process = mock.Mock(pid=4321)
+        process.poll.return_value = None
+
+        with (
+            mock.patch.object(cli, "wait_for_acknowledgement", side_effect=[False, True]),
+            mock.patch.object(cli.subprocess, "Popen", return_value=process) as popen,
+        ):
+            self.assertEqual(cli.launch_app(case["ticket"], "TP_A"), 0)
+
+        popen.assert_called_once()
+        self.assertEqual(
+            popen.call_args.args[0],
+            [
+                "openboardview",
+                "-i",
+                str(board_file.resolve()),
+                "--ticket",
+                case["ticket"],
+                "--locate",
+                "TP_A",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi! I made this because board-level diagnosis was split between an AI chat, manual notes, and the boardview. I wanted one ticket to keep the measurement plan, results, and physical locations together.

This adds an optional `json-c` diagnostics panel. It stores readings and comments, prefills Actual values, jumps to each board location, zooms farther out on a second click, and skips dependent checks when a prerequisite fails. A portable Agent Skill is installed on first launch for Codex/OpenCode and Claude Code; existing unmanaged skills are not overwritten. An already-open matching window is reused.

If `json-c` is unavailable, the feature is not built.

### Quick AI test

Build and install this branch with `json-c` and Python 3 available, launch OpenBoardView once, then restart the local AI client so it discovers the skill. From a folder containing the named boardview and schematic, try this common no-power fault:

> Ticket 1001. I am diagnosing an Apple MacBook Pro A1707 (2017) with logic board 820-00928. It does not power on. A known-good USB-C charger negotiates 20 V but draws 0.00 A. PPDCIN_G3H is 20 V, while PPBUS_G3H is 0 V and measures about 2 ohms to ground with the charger and battery disconnected. There is no obvious visible damage. The 820-00928 boardview and schematic are in this folder. Create and open the first diagnostic checklist in OpenBoardView.

Enter the readings and press **Finish round**, then ask:

> I finished the measurements for ticket 1001. Review the results and create the next diagnostic round if needed.

The ticket lifecycle, dependencies, plan validation, and window reuse have automated coverage; I also tested native builds with diagnostics enabled and disabled. I used AI to design, implement, and test this change.
